### PR TITLE
PyDOE2 and Python 3 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.pyd
 *.pyc
 *~
 *build*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 branches:
   only:
     - master
-    - ft-mixture-of-experts
 
 sudo: required
 
@@ -15,6 +14,7 @@ language: generic
 
 env:
 - PY=2.7
+- PY=3.6
 
 addons:
   apt:

--- a/README.md
+++ b/README.md
@@ -13,17 +13,7 @@ SMT is distributed under the New BSD license.
 Version 0.2
 
 # Required packages
-Numpy    >= Version 1.9.2
-
-Scikit-learn  >= Version 0.13.1
-
-pyDOE >= Version 0.3.8
-
-six
-
-Cython
-
-Scipy
+SMT depends on the following modules: numpy, scipy, sk-learn, pyDOE2 and Cython. 
 
 # Installation
 Clone the repository from github then run:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ init:
   - IF "%ARCH%"=="64" (call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86_amd64)
 
 install:
-  - pip install -i https://pypi.anaconda.org/carlkl/simple mingwpy
+  #pip install -i https://pypi.anaconda.org/carlkl/simple mingwpy
   #Grab testflo for running test, to ensure examples are run
   - pip install git+https://github.com/OpenMDAO/testflo.git
   - pip install git+https://github.com/hwangjt/sphinx_auto_embed.git

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,11 +7,12 @@ platform:
 
 environment:
   matrix:
+    - PYTHON: 3.6
     - PYTHON: 2.7
 
 init:
   - set CONDA=Miniconda
-  - if "%PYTHON%" == "3.4" (set CONDA=%CONDA%3)
+  - if "%PYTHON%" == "3.6" (set CONDA=%CONDA%3)
   - if "%PLATFORM%" == "x64" (set CONDA=%CONDA%-x64)
   - echo %CONDA%
   - set PATH=C:\%CONDA%;C:\%CONDA%\Scripts;%PATH%

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(name='smt',
     ],
     install_requires=[
         'scikit-learn',
-        'pyDOE',
+        'pyDOE2',
         'matplotlib',
         'numpydoc',
         'six>=1.10',

--- a/smt/extensions/tests/test_moe.py
+++ b/smt/extensions/tests/test_moe.py
@@ -204,7 +204,7 @@ class TestMOE(SMTestCase):
         x0 = np.linspace(xlim[0, 0], xlim[0, 1], 20)
         x1 = np.linspace(xlim[1, 0], xlim[1, 1], 20)
         xv, yv = np.meshgrid(x0, x1)
-        x = np.array(zip(xv.reshape((-1,)), yv.reshape((-1,))))
+        x = np.array(list(zip(xv.reshape((-1,)), yv.reshape((-1,)))))
         prob = moe._proba_cluster(x)
 
         plt.subplot(221, projection='3d')

--- a/smt/sampling_methods/lhs.py
+++ b/smt/sampling_methods/lhs.py
@@ -3,10 +3,10 @@ Author: Dr. John T. Hwang <hwangjt@umich.edu>
 
 This package is distributed under New BSD license.
 
-LHS sampling; uses the pyDOE package.
+LHS sampling; uses the pyDOE2 package.
 """
 from __future__ import division
-import pyDOE
+from pyDOE2 import lhs
 from six.moves import range
 from scipy.spatial.distance import pdist, cdist
 import numpy as np
@@ -38,7 +38,7 @@ class LHS(SamplingMethod):
         xlimits = self.options['xlimits']
         nx = xlimits.shape[0]
         if self.options['criterion'] != 'ese':
-            return pyDOE.lhs(nx, samples=n, criterion=self.options['criterion'])
+            return lhs(nx, samples=n, criterion=self.options['criterion'])
         elif self.options['criterion'] == 'ese':
             return self._ese(nx,n)
 

--- a/smt/surrogate_models/krg_based.py
+++ b/smt/surrogate_models/krg_based.py
@@ -193,7 +193,7 @@ class KrgBased(SurrogateModel):
         try:            
             C = linalg.cholesky(R, lower=True)
         except (linalg.LinAlgError, ValueError) as e:
-            print "exception : ", e
+            print("exception : ", e)
             return reduced_likelihood_function_value, par
         
         # Get generalized least squares solution

--- a/smt/utils/kriging_utils.py
+++ b/smt/utils/kriging_utils.py
@@ -6,7 +6,7 @@ This package is distributed under New BSD license.
 
 import numpy as np
 from sklearn.cross_decomposition.pls_ import PLSRegression as pls
-from pyDOE import *
+from pyDOE2 import bbdesign
 
 def standardization(X,y,copy=False):
 


### PR DESCRIPTION
- Use pyDOE2 instead of pyDOE
- Fix python 3 compatibility
- Activate Travis and Appveyor on Python 3.6