### PR TITLE
matplotlib.use(Agg) first

### DIFF
--- a/smt/extensions/tests/test_mfk.py
+++ b/smt/extensions/tests/test_mfk.py
@@ -5,21 +5,17 @@ Created on Mon May 07 14:20:11 2018
 @author: m.meliani
 """
 
-
-import matplotlib.pyplot as plt
-import unittest
 import matplotlib
-from smt.extensions import MFK
 matplotlib.use('Agg')
 
-
-
-
+import unittest
+from smt.extensions import MFK
 
 class TestMFK(unittest.TestCase):
     @staticmethod
     def run_mfk_example(self):
         import numpy as np
+        import matplotlib.pyplot as plt
         from smt.extensions import MFK
         # Define the 
         def LF_function(x):

--- a/smt/extensions/tests/test_moe.py
+++ b/smt/extensions/tests/test_moe.py
@@ -4,6 +4,9 @@ Author: Remi Lafage <remi.lafage@onera.fr>
 This package is distributed under New BSD license.
 '''
 
+import matplotlib
+matplotlib.use('Agg')
+
 import unittest
 import numpy as np
 from sys import argv
@@ -13,9 +16,6 @@ from smt.utils.sm_test_case import SMTestCase
 from smt.problems import Branin, LpNorm
 from smt.sampling_methods import FullFactorial
 from smt.utils.misc import compute_rms_error
-
-import matplotlib.pyplot as plt
-from mpl_toolkits.mplot3d import Axes3D
 
 class TestMOE(SMTestCase):
     """
@@ -55,6 +55,9 @@ class TestMOE(SMTestCase):
         rms_error = compute_rms_error(moe, xe, ye)
         self.assert_error(rms_error, 0., 3e-1)
         if TestMOE.plot:
+            import matplotlib.pyplot as plt
+            from mpl_toolkits.mplot3d import Axes3D
+
             y = moe.predict_values(xe)
             plt.figure(1)
             plt.plot(ye, ye,'-.')
@@ -96,6 +99,9 @@ class TestMOE(SMTestCase):
         self.assert_error(rms_error, 0., 1e-1)
 
         if TestMOE.plot:
+            import matplotlib.pyplot as plt
+            from mpl_toolkits.mplot3d import Axes3D
+
             y = moe.predict_values(xe)
             plt.figure(1)
             plt.plot(ye, ye,'-.')
@@ -138,6 +144,9 @@ class TestMOE(SMTestCase):
         self.assert_error(rms_error, 0., 1e-1)
 
         if TestMOE.plot:
+            import matplotlib.pyplot as plt
+            from mpl_toolkits.mplot3d import Axes3D
+
             y = moe.analyse_results(x=xe, operation='predict_values')
             plt.figure(1)
             plt.plot(ye, ye,'-.')

--- a/smt/problems/tests/test_problem_examples.py
+++ b/smt/problems/tests/test_problem_examples.py
@@ -2,7 +2,7 @@ import unittest
 
 import matplotlib
 matplotlib.use('Agg')
-
+matplotlib.pyplot.switch_backend('Agg')
 
 class Test(unittest.TestCase):
 


### PR DESCRIPTION
When using testflo, matplotlib plotting should be disable. (see #135)
To do that <code>matplotlib.use('Agg')</code> has to be called as soon as matplotlib is imported.
This PR fixes that for moe and mfk.
However, I had to add the following line : 
<code>matplotlib.pyplot.switch_backend('Agg')</code>
at the beginning of <code>smt/problems/tests/test_problem_examples.py</code> to make it work on linux.
Weirdly on windows, the problem does not show up even without that PR.



