### PR TITLE
Correlation bug fix in variance prediction

### DIFF
--- a/smt/surrogate_models/krg_based.py
+++ b/smt/surrogate_models/krg_based.py
@@ -375,7 +375,7 @@ class KrgBased(SurrogateModel):
         d = self._componentwise_distance(dx)
 
         # Compute the correlation function
-        r = self.options["corr"](self.optimal_theta, d).reshape(n_eval, self.nt)
+        r = self._correlation_types[self.options["corr"]](self.optimal_theta, d).reshape(n_eval, self.nt)
 
         C = self.optimal_par["C"]
         rt = linalg.solve_triangular(C, r.T, lower=True)


### PR DESCRIPTION
The correlation function was not correctly called in the variance prediction of Kriging-based surrogate models: the function call was done on the option value directly, which is a str, resulting in a TypeError exception.