### PR TITLE
allow py2.7 failures on osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,6 @@ matrix:
     - os: osx
       env: PY=3.7
 
-jobs:
-  allow_failures:
-    - os: osx
-      env: PY=2.7
-
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,17 +12,14 @@ matrix:
     - os: linux
       env: PY=3.7
     - os: osx
-      env: PY=2.7
-    - os: osx
       env: PY=3.6
+    - os: osx
+      env: PY=3.7
 
 jobs:
   allow_failures:
     - os: osx
       env: PY=2.7
-
-osx_image: xcode9.4
-dist: xenial
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,11 @@ matrix:
     - os: osx
       env: PY=3.6
 
+jobs:
+  allow_failures:
+    - os: osx
+      env: PY=2.7
+
 osx_image: xcode9.4
 dist: xenial
 


### PR DESCRIPTION
as miniconda 2 install seems to fail on osx 

<pre>
$ if [ "$TRAVIS_OS_NAME" = "osx" ]; then if [ "$PY" = "2.7" ]; then wget https://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh -O miniconda.sh; else wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh; fi else if [ "$PY" = "2.7" ]; then wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh; else wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh; fi fi
install.2
17.99s$ bash miniconda.sh -b -p $HOME/miniconda
install.3
0.01s$ export PATH="$HOME/miniconda/bin:$PATH"
install.4
0.01s$ hash -r
install.5
0.24s$ conda config --set always_yes yes --set changeps1 no
install.6
26.96s$ conda update -q conda
0.74s$ conda info -a

# >>>>>>>>>>>>>>>>>>>>>> ERROR REPORT <<<<<<<<<<<<<<<<<<<<<<
    Traceback (most recent call last):
      File "/Users/travis/miniconda/lib/python2.7/site-packages/conda/exceptions.py", line 1079, in __call__
        return func(*args, **kwargs)
      File "/Users/travis/miniconda/lib/python2.7/site-packages/conda/cli/main.py", line 84, in _main
        exit_code = do_call(args, p)
      File "/Users/travis/miniconda/lib/python2.7/site-packages/conda/cli/conda_argparse.py", line 80, in do_call
        module = import_module(relative_mod, __name__.rsplit('.', 1)[0])
      File "/Users/travis/miniconda/lib/python2.7/importlib/__init__.py", line 37, in import_module
        __import__(name)
      File "/Users/travis/miniconda/lib/python2.7/site-packages/conda/cli/main_info.py", line 19, in <module>
        from ..core.index import _supplement_index_with_system
      File "/Users/travis/miniconda/lib/python2.7/site-packages/conda/core/index.py", line 10, in <module>
        from .package_cache_data import PackageCacheData
      File "/Users/travis/miniconda/lib/python2.7/site-packages/conda/core/package_cache_data.py", line 15, in <module>
        from .path_actions import CacheUrlAction, ExtractPackageAction
      File "/Users/travis/miniconda/lib/python2.7/site-packages/conda/core/path_actions.py", line 30, in <module>
        from ..gateways.connection.download import download
      File "/Users/travis/miniconda/lib/python2.7/site-packages/conda/gateways/connection/download.py", line 13, in <module>
        import ctypes
      File "/Users/travis/miniconda/lib/python2.7/ctypes/__init__.py", line 7, in <module>
        from _ctypes import Union, Structure, Array
    ImportError: dlopen(/Users/travis/miniconda/lib/python2.7/lib-dynload/_ctypes.so, 2): Library not loaded: @rpath/libffi.6.dylib
      Referenced from: /Users/travis/miniconda/lib/python2.7/lib-dynload/_ctypes.so
      Reason: image not found
`$ /Users/travis/miniconda/bin/conda info -a`

An unexpected error has occurred. Conda has prepared the above report.
Upload successful.
The command "conda info -a" failed and exited with 1 during .
</pre>