### PR TITLE
Fix setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ smt/src/rmts/rmtsclib.cpp
 .pytest_cache/
 /env
 /venv
+/pip-wheel-metadata

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -15,6 +15,7 @@ SMT has been developed thanks to contributions from:
 * Frederick Zahle <frza@dtu.dk>
 * Jasper Bussmaker <jasper.bussemaker@gmail.com>
 * Julien Schueller <schueller@phimeca.com>
+* Lucas Alber <lucasd.alber@gmail.com>
 * Mostafa Meliani <melimostafa@gmail.com>
 * Nina Moëllo <nina.moello@gmail.com>
 * Paul Saves <paul.saves@alumni.enac.fr>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "numpy", "Cython"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pytest
+pytest-xdist # allows running parallel testing with pytest -n <num_workers>

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 Author: Dr. John T. Hwang <hwangjt@umich.edu>
         Dr. Mohamed A. Bouhlel <mbouhlel@umich.edu>
         Remi Lafage <remi.lafage@onera.fr>
+        Lucas Alber <lucasd.alber@gmail.com>
 
 This package is distributed under New BSD license.
 """

--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,10 @@ Author: Dr. John T. Hwang <hwangjt@umich.edu>
 This package is distributed under New BSD license.
 """
 from setuptools import setup, Extension
-import os
 import sys
-from subprocess import call
+import numpy as np
+from Cython.Build import cythonize
+
 from smt import __version__
 
 CLASSIFIERS = """\
@@ -42,21 +43,6 @@ with respect to the training data. It also includes new surrogate models
 that are not available elsewhere: kriging by partial-least squares reduction 
 and energy-minimizing spline interpolation.
 """
-try:
-    import numpy as np
-except ImportError:
-    print("Numpy import failed: please install numpy module")
-    exit(-1)
-
-try:
-    import Cython
-except ImportError:
-    print("Cython import failed: try to install it using pip module...")
-    import pip
-
-    pip.main(["install", "Cython"])
-
-from Cython.Build import cythonize
 
 extra_compile_args = []
 if not sys.platform.startswith("win"):


### PR DESCRIPTION
- Autoinstall dependencies needed for setup.py (numpy, Cython, wheel, setuptools)
- Added requirements.txt for developers

Should I add a specific version for scikit-learn as mentioned in #272?