### PR TITLE
Do not scale the samples by default

### DIFF
--- a/smt/sampling_methods/full_factorial.py
+++ b/smt/sampling_methods/full_factorial.py
@@ -5,6 +5,7 @@ This package is distributed under New BSD license.
 
 Full-factorial sampling.
 """
+from smt.utils.misc import scale_to_xlimits
 import numpy as np
 
 from smt.sampling_methods.sampling_method import SamplingMethod
@@ -63,4 +64,4 @@ class FullFactorial(SamplingMethod):
         for kx in range(nx):
             x[:, kx] = x_list[kx].reshape(np.prod(num_list))[:nt]
 
-        return x
+        return scale_to_xlimits(x, xlimits)

--- a/smt/sampling_methods/full_factorial.py
+++ b/smt/sampling_methods/full_factorial.py
@@ -5,13 +5,12 @@ This package is distributed under New BSD license.
 
 Full-factorial sampling.
 """
-from smt.utils.misc import scale_to_xlimits
 import numpy as np
 
-from smt.sampling_methods.sampling_method import SamplingMethod
+from smt.sampling_methods.sampling_method import ScaledSamplingMethod
 
 
-class FullFactorial(SamplingMethod):
+class FullFactorial(ScaledSamplingMethod):
     def _initialize(self):
         self.options.declare(
             "weights",
@@ -28,7 +27,9 @@ class FullFactorial(SamplingMethod):
 
     def _compute(self, nt):
         """
-        Compute the requested number of sampling points.
+        Implemented by sampling methods to compute the requested number of sampling points.
+
+        The number of dimensions (nx) is determined based on `xlimits.shape[0]`.
 
         Arguments
         ---------
@@ -38,7 +39,7 @@ class FullFactorial(SamplingMethod):
         Returns
         -------
         ndarray[nt, nx]
-            The sampling locations in the input space.
+            The sampling locations in the unit hypercube.
         """
         xlimits = self.options["xlimits"]
         nx = xlimits.shape[0]
@@ -64,4 +65,4 @@ class FullFactorial(SamplingMethod):
         for kx in range(nx):
             x[:, kx] = x_list[kx].reshape(np.prod(num_list))[:nt]
 
-        return scale_to_xlimits(x, xlimits)
+        return x

--- a/smt/sampling_methods/lhs.py
+++ b/smt/sampling_methods/lhs.py
@@ -5,6 +5,7 @@ This package is distributed under New BSD license.
 
 LHS sampling; uses the pyDOE2 package.
 """
+from smt.utils.misc import scale_to_xlimits
 from pyDOE2 import lhs
 from scipy.spatial.distance import pdist, cdist
 import numpy as np
@@ -63,14 +64,14 @@ class LHS(SamplingMethod):
             self.random_state = np.random.RandomState()
 
         if self.options["criterion"] != "ese":
-            return lhs(
+            return scale_to_xlimits(lhs(
                 nx,
                 samples=nt,
                 criterion=self.options["criterion"],
                 random_state=self.random_state,
-            )
+            ), xlimits)
         elif self.options["criterion"] == "ese":
-            return self._ese(nx, nt)
+            return scale_to_xlimits(self._ese(nx, nt), xlimits)
 
     def _maximinESE(
         self,

--- a/smt/sampling_methods/lhs.py
+++ b/smt/sampling_methods/lhs.py
@@ -5,15 +5,14 @@ This package is distributed under New BSD license.
 
 LHS sampling; uses the pyDOE2 package.
 """
-from smt.utils.misc import scale_to_xlimits
 from pyDOE2 import lhs
 from scipy.spatial.distance import pdist, cdist
 import numpy as np
 
-from smt.sampling_methods.sampling_method import SamplingMethod
+from smt.sampling_methods.sampling_method import ScaledSamplingMethod
 
 
-class LHS(SamplingMethod):
+class LHS(ScaledSamplingMethod):
     def _initialize(self):
         self.options.declare(
             "criterion",
@@ -41,7 +40,9 @@ class LHS(SamplingMethod):
 
     def _compute(self, nt):
         """
-        Compute the requested number of sampling points.
+        Implemented by sampling methods to compute the requested number of sampling points.
+
+        The number of dimensions (nx) is determined based on `xlimits.shape[0]`.
 
         Arguments
         ---------
@@ -51,7 +52,7 @@ class LHS(SamplingMethod):
         Returns
         -------
         ndarray[nt, nx]
-            The sampling locations in the input space.
+            The sampling locations in the unit hypercube.
         """
         xlimits = self.options["xlimits"]
         nx = xlimits.shape[0]
@@ -64,14 +65,14 @@ class LHS(SamplingMethod):
             self.random_state = np.random.RandomState()
 
         if self.options["criterion"] != "ese":
-            return scale_to_xlimits(lhs(
+            return lhs(
                 nx,
                 samples=nt,
                 criterion=self.options["criterion"],
                 random_state=self.random_state,
-            ), xlimits)
+            )
         elif self.options["criterion"] == "ese":
-            return scale_to_xlimits(self._ese(nx, nt), xlimits)
+            return self._ese(nx, nt)
 
     def _maximinESE(
         self,

--- a/smt/sampling_methods/random.py
+++ b/smt/sampling_methods/random.py
@@ -5,6 +5,7 @@ This package is distributed under New BSD license.
 
 Random sampling.
 """
+from smt.utils.misc import scale_to_xlimits
 import numpy as np
 
 from smt.sampling_methods.sampling_method import SamplingMethod
@@ -27,4 +28,4 @@ class Random(SamplingMethod):
         """
         xlimits = self.options["xlimits"]
         nx = xlimits.shape[0]
-        return np.random.rand(nt, nx)
+        return scale_to_xlimits(np.random.rand(nt, nx), xlimits)

--- a/smt/sampling_methods/random.py
+++ b/smt/sampling_methods/random.py
@@ -5,16 +5,17 @@ This package is distributed under New BSD license.
 
 Random sampling.
 """
-from smt.utils.misc import scale_to_xlimits
 import numpy as np
 
-from smt.sampling_methods.sampling_method import SamplingMethod
+from smt.sampling_methods.sampling_method import ScaledSamplingMethod
 
 
-class Random(SamplingMethod):
+class Random(ScaledSamplingMethod):
     def _compute(self, nt):
         """
-        Compute the requested number of sampling points.
+        Implemented by sampling methods to compute the requested number of sampling points.
+
+        The number of dimensions (nx) is determined based on `xlimits.shape[0]`.
 
         Arguments
         ---------
@@ -24,8 +25,8 @@ class Random(SamplingMethod):
         Returns
         -------
         ndarray[nt, nx]
-            The sampling locations in the input space.
+            The sampling locations in the unit hypercube.
         """
         xlimits = self.options["xlimits"]
         nx = xlimits.shape[0]
-        return scale_to_xlimits(np.random.rand(nt, nx), xlimits)
+        return np.random.rand(nt, nx)

--- a/smt/sampling_methods/sampling_method.py
+++ b/smt/sampling_methods/sampling_method.py
@@ -64,14 +64,7 @@ class SamplingMethod(object, metaclass=ABCMeta):
         ndarray[nt, nx]
             The sampling locations in the input space.
         """
-        xlimits = self.options["xlimits"]
-        nx = xlimits.shape[0]
-
-        x = self._compute(nt)
-        for kx in range(nx):
-            x[:, kx] = xlimits[kx, 0] + x[:, kx] * (xlimits[kx, 1] - xlimits[kx, 0])
-
-        return x
+        return self._compute(nt)
 
     @abstractmethod
     def _compute(self, nt: int) -> np.ndarray:

--- a/smt/sampling_methods/sampling_method.py
+++ b/smt/sampling_methods/sampling_method.py
@@ -84,3 +84,68 @@ class SamplingMethod(object, metaclass=ABCMeta):
             The sampling locations in the input space.
         """
         raise Exception("This sampling method has not been implemented correctly")
+
+
+class ScaledSamplingMethod(SamplingMethod):
+    """ This class describes an sample method which generates samples in the unit hypercube.
+
+    The __call__ method does scale the generated samples accordingly to the defined xlimits.
+    """
+
+    def __call__(self, nt: int) -> np.ndarray:
+        """
+        Compute the requested number of sampling points.
+
+        The number of dimensions (nx) is determined based on `xlimits.shape[0]`.
+
+        Arguments
+        ---------
+        nt : int
+            Number of points requested.
+
+        Returns
+        -------
+        ndarray[nt, nx]
+            The sampling locations in the input space.
+        """
+        return _scale_to_xlimits(self._compute(nt), self.options["xlimits"])
+
+    @abstractmethod
+    def _compute(self, nt: int) -> np.ndarray:
+        """
+        Implemented by sampling methods to compute the requested number of sampling points.
+
+        The number of dimensions (nx) is determined based on `xlimits.shape[0]`.
+
+        Arguments
+        ---------
+        nt : int
+            Number of points requested.
+
+        Returns
+        -------
+        ndarray[nt, nx]
+            The sampling locations in the unit hypercube.
+        """
+        raise Exception("This sampling method has not been implemented correctly")
+
+
+def _scale_to_xlimits(samples: np.ndarray, xlimits: np.ndarray) -> np.ndarray:
+    """ Scales the samples from the unit hypercube to the specified limits.
+
+    Parameters
+    ----------
+    samples : np.ndarray
+        The samples with coordinates in [0,1]
+    xlimits : np.ndarray
+        The xlimits
+
+    Returns
+    -------
+    np.ndarray
+        The scaled samples.
+    """
+    nx = xlimits.shape[0]
+    for kx in range(nx):
+        samples[:, kx] = xlimits[kx, 0] + samples[:, kx] * (xlimits[kx, 1] - xlimits[kx, 0])
+    return samples

--- a/smt/utils/misc.py
+++ b/smt/utils/misc.py
@@ -50,3 +50,24 @@ def compute_rms_error(sm, xe=None, ye=None, kx=None):
         num = np.linalg.norm(yt2 - yt)
         den = np.linalg.norm(yt)
         return num / den
+
+
+def scale_to_xlimits(samples: np.ndarray, xlimits: np.ndarray) -> np.ndarray:
+    """ Scales the samples from [0,1] to the specified limits.
+
+    Parameters
+    ----------
+    samples : np.ndarray
+        The samples
+    xlimits : np.ndarray
+        The xlimits
+
+    Returns
+    -------
+    np.ndarray
+        The scaled samples.
+    """
+    nx = xlimits.shape[0]
+    for kx in range(nx):
+        samples[:, kx] = xlimits[kx, 0] + samples[:, kx] * (xlimits[kx, 1] - xlimits[kx, 0])
+    return samples

--- a/smt/utils/misc.py
+++ b/smt/utils/misc.py
@@ -50,24 +50,3 @@ def compute_rms_error(sm, xe=None, ye=None, kx=None):
         num = np.linalg.norm(yt2 - yt)
         den = np.linalg.norm(yt)
         return num / den
-
-
-def scale_to_xlimits(samples: np.ndarray, xlimits: np.ndarray) -> np.ndarray:
-    """ Scales the samples from [0,1] to the specified limits.
-
-    Parameters
-    ----------
-    samples : np.ndarray
-        The samples
-    xlimits : np.ndarray
-        The xlimits
-
-    Returns
-    -------
-    np.ndarray
-        The scaled samples.
-    """
-    nx = xlimits.shape[0]
-    for kx in range(nx):
-        samples[:, kx] = xlimits[kx, 0] + samples[:, kx] * (xlimits[kx, 1] - xlimits[kx, 0])
-    return samples


### PR DESCRIPTION
The \_\_call\_\_ method does scale the result from _compute() by default. This is unexpected and not documented. Also, it does prevent subclasses to generate samples in the input space directly.