### PR TITLE
CI maintainance

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,6 @@ jobs:
         pip install -e .
 
     - name: Test with pytest
-      run: pytest
+      run: pytest --durations=0
 
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.7', '3.8', '3.9']
+        python-version: ['3.8', '3.9']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tests_coverage.yml
+++ b/.github/workflows/tests_coverage.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.6']
+        python-version: ['3.7']
 
     steps:
     - uses: actions/checkout@v2

--- a/smt/applications/tests/test_ego.py
+++ b/smt/applications/tests/test_ego.py
@@ -475,13 +475,15 @@ class TestEGO(SMTestCase):
             def _evaluate(self, x, kx):
                 assert kx is None
                 response = self.super._evaluate(x, kx)
-                sens = np.hstack(self.super._evaluate(x, ki) for ki in range(x.shape[1]))
+                sens = np.hstack(
+                    self.super._evaluate(x, ki) for ki in range(x.shape[1])
+                )
                 return np.hstack((response, sens))
 
         fun = TensorProductIndirect(ndim=2, func="exp")
 
         # Construction of the DOE
-        sampling = LHS(xlimits=fun.xlimits, criterion="m")
+        sampling = LHS(xlimits=fun.xlimits, criterion="m", random_state=42)
         xdoe = sampling(20)
         ydoe = fun(xdoe)
 
@@ -505,6 +507,7 @@ class TestEGO(SMTestCase):
             surrogate=sm,
             n_start=30,
             enable_tunneling=False,
+            random_state=42,
         )
         x_opt, _, _, _, _ = ego.optimize(fun=fun)
 


### PR DESCRIPTION
* Remove Python 3.6 from CI tests as it has reached its EOL
* Test EGO/GEKPLS with seeds to avoid random crash in svd call on MacOS
