### PR TITLE
Fix EI to work with 2D `y_data` as used in GEKPLS

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -15,6 +15,7 @@ SMT has been developed thanks to contributions from:
 * Frederick Zahle
 * Jasper Bussemaker
 * Julien Schueller
+* Laurent Wilkens
 * Lucas Alber
 * Mostafa Meliani
 * Nina Moëllo
@@ -26,4 +27,3 @@ SMT has been developed thanks to contributions from:
 * Ruben Conde
 * Steven Berguin
 * Vincent Drouet
-* Laurent Wilkens

--- a/smt/applications/ego.py
+++ b/smt/applications/ego.py
@@ -207,7 +207,7 @@ class EGO(SurrogateBasedApplication):
 
     def EI(self, points, y_data, enable_tunneling=False, x_data=None):
         """Expected improvement"""
-        f_min = np.min(y_data)
+        f_min = y_data[np.argmin(y_data[:, 0])]
         pred = self.gpr.predict_values(points)
         sig = np.sqrt(self.gpr.predict_variances(points))
         args0 = (f_min - pred) / sig
@@ -355,7 +355,7 @@ class EGO(SurrogateBasedApplication):
 
         if criterion == "EI":
             self.obj_k = lambda x: -self.EI(
-                np.atleast_2d(x), y_data, enable_tunneling, x_data
+                np.atleast_2d(x), np.atleast_2d(y_data), enable_tunneling, x_data
             )
         elif criterion == "SBO":
             self.obj_k = lambda x: self.SBO(np.atleast_2d(x))

--- a/smt/applications/tests/test_ego.py
+++ b/smt/applications/tests/test_ego.py
@@ -464,7 +464,8 @@ class TestEGO(SMTestCase):
         x, _ = ego._find_best_point(xdoe, ydoe, enable_tunneling=False)
         self.assertAlmostEqual(6.5, float(x), delta=1)
 
-    def test_ego_gek(self):
+    @staticmethod
+    def initialize_EGO_GEK(func="exp", criterion='LCB'):
         from smt.problems import TensorProduct
 
         class TensorProductIndirect(TensorProduct):
@@ -480,7 +481,7 @@ class TestEGO(SMTestCase):
                 )
                 return np.hstack((response, sens))
 
-        fun = TensorProductIndirect(ndim=2, func="exp")
+        fun = TensorProductIndirect(ndim=2, func=func)
 
         # Construction of the DOE
         sampling = LHS(xlimits=fun.xlimits, criterion="m", random_state=42)
@@ -502,17 +503,35 @@ class TestEGO(SMTestCase):
             xdoe=xdoe,
             ydoe=ydoe,
             n_iter=5,
-            criterion="LCB",
+            criterion=criterion,
             xlimits=fun.xlimits,
             surrogate=sm,
             n_start=30,
             enable_tunneling=False,
             random_state=42,
         )
+
+        return ego, fun
+
+    def test_ego_gek(self):
+        ego, fun = self.initialize_EGO_GEK()
         x_opt, _, _, _, _ = ego.optimize(fun=fun)
 
         self.assertAlmostEqual(-1.0, float(x_opt[0]), delta=1e-4)
         self.assertAlmostEqual(-1.0, float(x_opt[1]), delta=1e-4)
+
+    def test_EI_GEK(self):
+        ego, fun = self.initialize_EGO_GEK(func='cos', criterion='EI')
+        x_data, y_data = ego._setup_optimizer(fun)
+        ego._train_gpr(x_data, y_data)
+
+        # Test the EI value at the following point
+        ei = ego.EI(np.array([[0.8398599985874058, -0.3240337426231973]]))
+
+        self.assertListEqual(
+            ei.tolist(),
+            [[6.8764211903636255e-12, 1.4780384733929935e-10, 2.762229481453051]]
+        )
 
     def test_qei_criterion_default(self):
         fun = TestEGO.function_test_1d

--- a/smt/applications/tests/test_ego.py
+++ b/smt/applications/tests/test_ego.py
@@ -465,7 +465,7 @@ class TestEGO(SMTestCase):
         self.assertAlmostEqual(6.5, float(x), delta=1)
 
     @staticmethod
-    def initialize_EGO_GEK(func="exp", criterion='LCB'):
+    def initialize_ego_gek(func="exp", criterion='LCB'):
         from smt.problems import TensorProduct
 
         class TensorProductIndirect(TensorProduct):
@@ -514,24 +514,21 @@ class TestEGO(SMTestCase):
         return ego, fun
 
     def test_ego_gek(self):
-        ego, fun = self.initialize_EGO_GEK()
+        ego, fun = self.initialize_ego_gek()
         x_opt, _, _, _, _ = ego.optimize(fun=fun)
 
         self.assertAlmostEqual(-1.0, float(x_opt[0]), delta=1e-4)
         self.assertAlmostEqual(-1.0, float(x_opt[1]), delta=1e-4)
 
-    def test_EI_GEK(self):
-        ego, fun = self.initialize_EGO_GEK(func='cos', criterion='EI')
+    def test_ei_gek(self):
+        ego, fun = self.initialize_ego_gek(func='cos', criterion='EI')
         x_data, y_data = ego._setup_optimizer(fun)
         ego._train_gpr(x_data, y_data)
 
         # Test the EI value at the following point
         ei = ego.EI(np.array([[0.8398599985874058, -0.3240337426231973]]))
 
-        self.assertListEqual(
-            ei.tolist(),
-            [[6.8764211903636255e-12, 1.4780384733929935e-10, 2.762229481453051]]
-        )
+        self.assertTrue(np.allclose(ei, [6.87642e-12, 1.47804e-10, 2.76223], atol=1e-3))
 
     def test_qei_criterion_default(self):
         fun = TestEGO.function_test_1d

--- a/smt/applications/tests/test_ego.py
+++ b/smt/applications/tests/test_ego.py
@@ -528,7 +528,7 @@ class TestEGO(SMTestCase):
         # Test the EI value at the following point
         ei = ego.EI(np.array([[0.8398599985874058, -0.3240337426231973]]))
 
-        self.assertTrue(np.allclose(ei, [6.87642e-12, 1.47804e-10, 2.76223], atol=1e-3))
+        self.assertTrue(np.allclose(ei, [6.87642e-12, 1.47804e-10, 2.76223], atol=1e-1))
 
     def test_qei_criterion_default(self):
         fun = TestEGO.function_test_1d


### PR DESCRIPTION
Fix for  PR #340. `EI()` Now correctly identifies the optimal design vector from `y_data`