### PR TITLE
Fix moe when test data are specified

### DIFF
--- a/smt/applications/ego.py
+++ b/smt/applications/ego.py
@@ -226,9 +226,9 @@ class EGO(SurrogateBasedApplication):
                     x = np.atleast_2d(x)
                     # if np.abs(p-x)<1:
                     # ei[i]=ei[i]*np.reciprocal(1+100*np.exp(-np.reciprocal(1-np.square(p-x))))
-                    pena = (
-                        EIp - self.EI(x, enable_tunneling=False)
-                    ) / np.power(np.linalg.norm(p - x), 4)
+                    pena = (EIp - self.EI(x, enable_tunneling=False)) / np.power(
+                        np.linalg.norm(p - x), 4
+                    )
                     if pena > 0:
                         ei[i] = ei[i] - pena
                     ei[i] = max(ei[i], 0)
@@ -323,9 +323,7 @@ class EGO(SurrogateBasedApplication):
         if self.gpr.supports["training_derivatives"]:
             for kx in range(self.gpr.nx):
                 self.gpr.set_training_derivatives(
-                    x_data,
-                    y_data[:, 1 + kx].reshape((y_data.shape[0], 1)),
-                    kx
+                    x_data, y_data[:, 1 + kx].reshape((y_data.shape[0], 1)), kx
                 )
         self.gpr.train()
 

--- a/smt/applications/moe.py
+++ b/smt/applications/moe.py
@@ -410,7 +410,7 @@ class MOE(SurrogateBasedApplication):
         cluster_classifier = self.cluster.predict(np.c_[xt, ct])
         clustered_values = self._cluster_values(np.c_[xt, yt], cluster_classifier)
 
-        # sort trained_values for each cluster
+        # sort test_values for each cluster only used in case of new model
         if new_model:
             test_cluster_classifier = self.cluster.predict(np.c_[xtest, ctest])
             clustered_test_values = self._cluster_values(
@@ -427,10 +427,10 @@ class MOE(SurrogateBasedApplication):
             else:
                 # retrain the experts
                 # used when self._training_values changed with expert best models already found
-                trained_values = np.array(clustered_values[i])
-                x_trained = trained_values[:, 0 : self.ndim]
-                y_trained = trained_values[:, self.ndim]
-                self._experts[i].set_training_values(x_trained, y_trained)
+                training_values = np.array(clustered_values[i])
+                xtrain = training_values[:, 0 : self.ndim]
+                ytrain = training_values[:, self.ndim]
+                self._experts[i].set_training_values(xtrain, ytrain)
                 self._experts[i].train()
 
     def _predict_hard_output(self, x, output_variances=False):

--- a/smt/applications/tests/test_ego.py
+++ b/smt/applications/tests/test_ego.py
@@ -465,7 +465,7 @@ class TestEGO(SMTestCase):
         self.assertAlmostEqual(6.5, float(x), delta=1)
 
     @staticmethod
-    def initialize_ego_gek(func="exp", criterion='LCB'):
+    def initialize_ego_gek(func="exp", criterion="LCB"):
         from smt.problems import TensorProduct
 
         class TensorProductIndirect(TensorProduct):
@@ -521,7 +521,7 @@ class TestEGO(SMTestCase):
         self.assertAlmostEqual(-1.0, float(x_opt[1]), delta=1e-4)
 
     def test_ei_gek(self):
-        ego, fun = self.initialize_ego_gek(func='cos', criterion='EI')
+        ego, fun = self.initialize_ego_gek(func="cos", criterion="EI")
         x_data, y_data = ego._setup_optimizer(fun)
         ego._train_gpr(x_data, y_data)
 
@@ -590,7 +590,7 @@ class TestEGO(SMTestCase):
 
             y_gp_plot = ego.gpr.predict_values(x_plot)
             y_gp_plot_var = ego.gpr.predict_variances(x_plot)
-            y_ei_plot = -ego.EI(x_plot, y_data_k)
+            y_ei_plot = -ego.EI(x_plot)
 
             ax = fig.add_subplot((n_iter + 1) // 2, 2, i + 1)
             ax1 = ax.twinx()
@@ -799,7 +799,7 @@ class TestEGO(SMTestCase):
                 ego.gpr.set_training_values(x_data_sub, y_data_sub)
                 ego.gpr.train()
 
-                y_ei_plot = -ego.EI(x_plot, y_data_sub)
+                y_ei_plot = -ego.EI(x_plot)
                 y_gp_plot = ego.gpr.predict_values(x_plot)
                 y_gp_plot_var = ego.gpr.predict_variances(x_plot)
 


### PR DESCRIPTION
This PR fixes a bug related to wrong test data usage to determine best models when test data are specifiedvia `xtest`, `ytest` options. Moreover, a `ctest` option to specify test derivatives outputs is added to be consistent.