### PR TITLE
Dependencies cleanup

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,11 +27,10 @@ jobs:
     - name: Install dependencies
       run: |
         pip install --upgrade pip
-        pip install numpy scipy cython scikit-learn pytest
-        pip install git+https://github.com/hwangjt/sphinx_auto_embed.git
+        pip install -r requirements.txt
         pip install -e .
 
     - name: Test with pytest
-      run: pytest --durations=0
+      run: pytest smt --durations=0
 
 

--- a/.github/workflows/tests_coverage.yml
+++ b/.github/workflows/tests_coverage.yml
@@ -27,8 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install --upgrade pip
-        pip install numpy scipy cython scikit-learn pytest
-        pip install git+https://github.com/hwangjt/sphinx_auto_embed.git
+        pip install -r requirements.txt
         pip list
         pip install -e .
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,5 +1,8 @@
 Cython
+numpy
+scipy
+scikit-learn
+pyDOE2
 numpydoc
 matplotlib
-scikit-learn
-pyDOE
+git+https://github.com/hwangjt/sphinx_auto_embed.git  # for doc generation 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,5 @@
 Cython
 numpydoc
+matplotlib
 scikit-learn
 pyDOE

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+matplotlib   # used in examples
 pytest
 pytest-xdist # allows running parallel testing with pytest -n <num_workers>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,8 @@
-matplotlib   # used in examples
+Cython
+numpy
+scipy
+scikit-learn
+pyDOE2
+matplotlib   # used in examples and tests
 pytest
 pytest-xdist # allows running parallel testing with pytest -n <num_workers>

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,6 @@ metadata = dict(
     ],
     install_requires=[
         "scikit-learn",
-        "packaging",
         "pyDOE2",
         "matplotlib",
         "numpydoc",

--- a/setup.py
+++ b/setup.py
@@ -106,8 +106,6 @@ metadata = dict(
     install_requires=[
         "scikit-learn",
         "pyDOE2",
-        "matplotlib",
-        "numpydoc",
         "scipy",
     ],
     python_requires=">=3.6",

--- a/smt/applications/mfk.py
+++ b/smt/applications/mfk.py
@@ -15,7 +15,6 @@ from scipy.linalg import solve_triangular
 from scipy import linalg
 from scipy.spatial.distance import cdist
 
-from packaging import version
 from sklearn.cross_decomposition import PLSRegression as pls
 
 from smt.surrogate_models.krg_based import KrgBased

--- a/smt/applications/mfkpls.py
+++ b/smt/applications/mfkpls.py
@@ -11,8 +11,6 @@ Adapted on January 2021 by Andres Lopez-Lopera to the new SMT version
 
 import numpy as np
 
-from packaging import version
-
 from sklearn.cross_decomposition import PLSRegression as pls
 from sklearn.metrics.pairwise import manhattan_distances
 

--- a/smt/surrogate_models/kpls.py
+++ b/smt/surrogate_models/kpls.py
@@ -6,7 +6,6 @@ This package is distributed under New BSD license.
 
 import numpy as np
 
-from packaging import version
 from sklearn.cross_decomposition import PLSRegression as pls
 
 from smt.surrogate_models.krg_based import KrgBased

--- a/smt/utils/kriging_utils.py
+++ b/smt/utils/kriging_utils.py
@@ -5,7 +5,6 @@ This package is distributed under New BSD license.
 """
 
 import numpy as np
-from packaging import version
 
 from sklearn.cross_decomposition import PLSRegression as pls
 


### PR DESCRIPTION
- [x] remove useless packaging from `install_requires`
- [x] move matplotlib from `install_requires` to `requirements.txt`
- [x] move numpydoc from `install_requires` to `doc/requirements.txt`

fixes #364 