### PR TITLE
Update derivatives predictions for vectors inputs and clean EGO

### DIFF
--- a/smt/applications/tests/test_ego.py
+++ b/smt/applications/tests/test_ego.py
@@ -250,7 +250,7 @@ class TestEGO(SMTestCase):
         x_opt, y_opt, _, _, _ = ego.optimize(fun=fun)
         # 3 optimal points possible: [-pi, 12.275], [pi, 2.275], [9.42478, 2.475]
         self.assertTrue(
-            np.allclose([[-3, 12.275]], x_opt, rtol=0.2)
+             np.allclose([[-3, 12.275]], x_opt, rtol=0.2)
             or np.allclose([[3, 2.275]], x_opt, rtol=0.2)
             or np.allclose([[9, 2.475]], x_opt, rtol=0.2)
         )
@@ -266,7 +266,7 @@ class TestEGO(SMTestCase):
         sm = KRG(print_global=False)
         mixint = MixedIntegerContext(xtypes, xlimits)
         sampling = MixedIntegerSamplingMethod(xtypes, xlimits, FullFactorial)
-        xdoe = sampling(10)
+        xdoe = sampling(20)
 
         ego = EGO(
             xdoe=xdoe,
@@ -286,7 +286,7 @@ class TestEGO(SMTestCase):
             or np.allclose([[3, 2.275]], x_opt, rtol=2)
             or np.allclose([[9, 2.475]], x_opt, rtol=2)
         )
-        self.assertAlmostEqual(0.494, float(y_opt), delta=1.5)
+        self.assertAlmostEqual(0.494, float(y_opt), delta=2)
 
     def test_branin_2D_mixed_tunnel(self):
         n_iter = 20

--- a/smt/applications/tests/test_ego.py
+++ b/smt/applications/tests/test_ego.py
@@ -282,11 +282,11 @@ class TestEGO(SMTestCase):
         x_opt, y_opt, _, _, _ = ego.optimize(fun=fun)
         # 3 optimal points possible: [-pi, 12.275], [pi, 2.275], [9.42478, 2.475]
         self.assertTrue(
-            np.allclose([[-3, 12.275]], x_opt, rtol=2)
-            or np.allclose([[3, 2.275]], x_opt, rtol=2)
-            or np.allclose([[9, 2.475]], x_opt, rtol=2)
+             np.allclose([[-3, 12.275]], x_opt, rtol=0.2)
+            or np.allclose([[3, 2.275]], x_opt, rtol=0.2)
+            or np.allclose([[9, 2.475]], x_opt, rtol=0.2)
         )
-        self.assertAlmostEqual(0.494, float(y_opt), delta=2)
+        self.assertAlmostEqual(0.494, float(y_opt), delta=1)
 
     def test_branin_2D_mixed_tunnel(self):
         n_iter = 20
@@ -298,7 +298,7 @@ class TestEGO(SMTestCase):
         sm = KRG(print_global=False)
         mixint = MixedIntegerContext(xtypes, xlimits)
         sampling = MixedIntegerSamplingMethod(xtypes, xlimits, FullFactorial)
-        xdoe = sampling(10)
+        xdoe = sampling(20)
 
         ego = EGO(
             xdoe=xdoe,
@@ -314,11 +314,11 @@ class TestEGO(SMTestCase):
         x_opt, y_opt, _, _, _ = ego.optimize(fun=fun)
         # 3 optimal points possible: [-pi, 12.275], [pi, 2.275], [9.42478, 2.475]
         self.assertTrue(
-            np.allclose([[-3, 12.275]], x_opt, atol=0.5)
-            or np.allclose([[3, 2.275]], x_opt, atol=0.5)
-            or np.allclose([[9, 2.475]], x_opt, atol=0.5)
+            np.allclose([[-3, 12.275]], x_opt,  rtol=2)
+            or np.allclose([[3, 2.275]], x_opt, rtol=2)
+            or np.allclose([[9, 2.475]], x_opt, rtol=2)
         )
-        self.assertAlmostEqual(0.494, float(y_opt), delta=1)
+        self.assertAlmostEqual(0.494, float(y_opt), delta=2)
 
     @staticmethod
     def function_test_mixed_integer(X):

--- a/smt/applications/tests/test_ego.py
+++ b/smt/applications/tests/test_ego.py
@@ -124,6 +124,25 @@ class TestEGO(SMTestCase):
         self.assertTrue(np.allclose([[1, 1]], x_opt, rtol=0.5))
         self.assertAlmostEqual(0.0, float(y_opt), delta=1)
 
+    def test_rosenbrock_2D_SBO(self):
+        n_iter = 20
+        fun = Rosenbrock(ndim=2)
+        xlimits = fun.xlimits
+        criterion = "SBO"  #'EI' or 'SBO' or 'LCB'
+
+        xdoe = FullFactorial(xlimits=xlimits)(40)
+        ego = EGO(
+            xdoe=xdoe,
+            n_iter=n_iter,
+            criterion=criterion,
+            xlimits=xlimits,
+            random_state=0,
+        )
+
+        x_opt, y_opt, _, _, _ = ego.optimize(fun=fun)
+        self.assertTrue(np.allclose([[1, 1]], x_opt, rtol=0.5))
+        self.assertAlmostEqual(0.0, float(y_opt), delta=1)
+
     def test_rosenbrock_2D_parallel(self):
         n_iter = 20
         n_parallel = 5
@@ -207,7 +226,7 @@ class TestEGO(SMTestCase):
         fun = Branin(ndim=2)
         xlimits = fun.xlimits
         criterion = "EI"  #'EI' or 'SBO' or 'LCB'
-        qEI = "KB"
+        qEI = "CLmin"
         xtypes = [ORD, FLOAT]
 
         sm = KRG(print_global=False)
@@ -315,7 +334,6 @@ class TestEGO(SMTestCase):
             xtypes=xtypes,
             xlimits=xlimits,
             surrogate=sm,
-            enable_tunneling=False,
             random_state=42,
         )
         _, y_opt, _, _, _ = ego.optimize(fun=TestEGO.function_test_mixed_integer)
@@ -349,7 +367,6 @@ class TestEGO(SMTestCase):
             xtypes=xtypes,
             xlimits=xlimits,
             surrogate=sm,
-            enable_tunneling=False,
             random_state=42,
             categorical_kernel=GOWER_KERNEL,
         )
@@ -384,7 +401,6 @@ class TestEGO(SMTestCase):
             xtypes=xtypes,
             xlimits=xlimits,
             surrogate=sm,
-            enable_tunneling=False,
             random_state=42,
             categorical_kernel=EXP_HOMO_HSPHERE_KERNEL,
         )
@@ -419,7 +435,6 @@ class TestEGO(SMTestCase):
             xtypes=xtypes,
             xlimits=xlimits,
             surrogate=sm,
-            enable_tunneling=False,
             random_state=42,
             categorical_kernel=EXP_HOMO_HSPHERE_KERNEL,
         )
@@ -460,11 +475,10 @@ class TestEGO(SMTestCase):
             criterion="LCB",
             xlimits=xlimits,
             n_start=30,
-            enable_tunneling=False,
             random_state=42,
         )
         _, _, _, _, _ = ego.optimize(fun=fun)
-        x, _ = ego._find_best_point(xdoe, ydoe, enable_tunneling=False)
+        x, _ = ego._find_best_point(xdoe, ydoe)
         self.assertAlmostEqual(6.5, float(x), delta=1)
 
     @staticmethod
@@ -510,7 +524,6 @@ class TestEGO(SMTestCase):
             xlimits=fun.xlimits,
             surrogate=sm,
             n_start=30,
-            enable_tunneling=False,
             random_state=42,
         )
 
@@ -539,7 +552,13 @@ class TestEGO(SMTestCase):
         xdoe = FullFactorial(xlimits=xlimits)(3)
         ydoe = fun(xdoe)
         ego = EGO(
-            xdoe=xdoe, ydoe=ydoe, n_iter=1, criterion="SBO", xlimits=xlimits, n_start=30
+            xdoe=xdoe,
+            ydoe=ydoe,
+            n_iter=1,
+            n_parallel=2,
+            criterion="SBO",
+            xlimits=xlimits,
+            n_start=30,
         )
         ego._setup_optimizer(fun)
         ego.gpr.set_training_values(xdoe, ydoe)
@@ -677,7 +696,7 @@ class TestEGO(SMTestCase):
             [[-5, 5], ["red", "green", "blue"], ["square", "circle"], [0, 2]]
         )
         criterion = "EI"  #'EI' or 'SBO' or 'LCB'
-        qEI = "KB"
+        qEI = "KBRand"
         sm = KRG(print_global=False)
         mixint = MixedIntegerContext(xtypes, xlimits)
         n_doe = 3
@@ -694,6 +713,7 @@ class TestEGO(SMTestCase):
             xlimits=xlimits,
             surrogate=sm,
             qEI=qEI,
+            n_parallel=2,
             random_state=42,
         )
 

--- a/smt/applications/tests/test_ego.py
+++ b/smt/applications/tests/test_ego.py
@@ -334,6 +334,7 @@ class TestEGO(SMTestCase):
             xtypes=xtypes,
             xlimits=xlimits,
             surrogate=sm,
+            enable_tunneling=False,
             random_state=42,
         )
         _, y_opt, _, _, _ = ego.optimize(fun=TestEGO.function_test_mixed_integer)
@@ -367,6 +368,7 @@ class TestEGO(SMTestCase):
             xtypes=xtypes,
             xlimits=xlimits,
             surrogate=sm,
+            enable_tunneling=False,
             random_state=42,
             categorical_kernel=GOWER_KERNEL,
         )
@@ -401,6 +403,7 @@ class TestEGO(SMTestCase):
             xtypes=xtypes,
             xlimits=xlimits,
             surrogate=sm,
+            enable_tunneling=False,
             random_state=42,
             categorical_kernel=EXP_HOMO_HSPHERE_KERNEL,
         )
@@ -435,6 +438,7 @@ class TestEGO(SMTestCase):
             xtypes=xtypes,
             xlimits=xlimits,
             surrogate=sm,
+            enable_tunneling=False,
             random_state=42,
             categorical_kernel=EXP_HOMO_HSPHERE_KERNEL,
         )
@@ -475,10 +479,11 @@ class TestEGO(SMTestCase):
             criterion="LCB",
             xlimits=xlimits,
             n_start=30,
+            enable_tunneling=False,
             random_state=42,
         )
         _, _, _, _, _ = ego.optimize(fun=fun)
-        x, _ = ego._find_best_point(xdoe, ydoe)
+        x, _ = ego._find_best_point(xdoe, ydoe, enable_tunneling=False)
         self.assertAlmostEqual(6.5, float(x), delta=1)
 
     @staticmethod

--- a/smt/applications/tests/test_ego.py
+++ b/smt/applications/tests/test_ego.py
@@ -266,7 +266,7 @@ class TestEGO(SMTestCase):
         sm = KRG(print_global=False)
         mixint = MixedIntegerContext(xtypes, xlimits)
         sampling = MixedIntegerSamplingMethod(xtypes, xlimits, FullFactorial)
-        xdoe = sampling(20)
+        xdoe = sampling(10)
 
         ego = EGO(
             xdoe=xdoe,
@@ -298,7 +298,7 @@ class TestEGO(SMTestCase):
         sm = KRG(print_global=False)
         mixint = MixedIntegerContext(xtypes, xlimits)
         sampling = MixedIntegerSamplingMethod(xtypes, xlimits, FullFactorial)
-        xdoe = sampling(20)
+        xdoe = sampling(30)
 
         ego = EGO(
             xdoe=xdoe,

--- a/smt/applications/tests/test_ego.py
+++ b/smt/applications/tests/test_ego.py
@@ -314,9 +314,9 @@ class TestEGO(SMTestCase):
         x_opt, y_opt, _, _, _ = ego.optimize(fun=fun)
         # 3 optimal points possible: [-pi, 12.275], [pi, 2.275], [9.42478, 2.475]
         self.assertTrue(
-            np.allclose([[-3, 12.275]], x_opt, rtol=0.2)
-            or np.allclose([[3, 2.275]], x_opt, rtol=0.2)
-            or np.allclose([[9, 2.475]], x_opt, rtol=0.2)
+            np.allclose([[-3, 12.275]], x_opt, atol=0.5)
+            or np.allclose([[3, 2.275]], x_opt, atol=0.5)
+            or np.allclose([[9, 2.475]], x_opt, atol=0.5)
         )
         self.assertAlmostEqual(0.494, float(y_opt), delta=1)
 

--- a/smt/applications/tests/test_ego.py
+++ b/smt/applications/tests/test_ego.py
@@ -282,11 +282,11 @@ class TestEGO(SMTestCase):
         x_opt, y_opt, _, _, _ = ego.optimize(fun=fun)
         # 3 optimal points possible: [-pi, 12.275], [pi, 2.275], [9.42478, 2.475]
         self.assertTrue(
-            np.allclose([[-3, 12.275]], x_opt, rtol=0.2)
-            or np.allclose([[3, 2.275]], x_opt, rtol=0.2)
-            or np.allclose([[9, 2.475]], x_opt, rtol=0.2)
+            np.allclose([[-3, 12.275]], x_opt, rtol=2)
+            or np.allclose([[3, 2.275]], x_opt, rtol=2)
+            or np.allclose([[9, 2.475]], x_opt, rtol=2)
         )
-        self.assertAlmostEqual(0.494, float(y_opt), delta=1)
+        self.assertAlmostEqual(0.494, float(y_opt), delta=1.5)
 
     def test_branin_2D_mixed_tunnel(self):
         n_iter = 20

--- a/smt/surrogate_models/krg_based.py
+++ b/smt/surrogate_models/krg_based.py
@@ -1253,7 +1253,6 @@ class KrgBased(SurrogateModel):
         rho2 = linalg.solve_triangular(C, F, lower=True)
         invKF = linalg.solve_triangular(C.T, rho2)
 
-
         A = f_x.T - np.dot(r, invKF)
 
         B = np.dot(F.T, invKF)

--- a/smt/surrogate_models/krg_based.py
+++ b/smt/surrogate_models/krg_based.py
@@ -1094,7 +1094,8 @@ class KrgBased(SurrogateModel):
             self.optimal_theta, d, derivative_params=derivative_dic
         )
         r = r.reshape(n_eval, self.nt)
-        dr = (dr.T).reshape(n_features_x, self.nt, n_eval)
+
+        drx = dr[:, kx].reshape(n_eval, self.nt)
 
         if self.options["poly"] == "constant":
             df = np.zeros((1, self.nx))
@@ -1116,7 +1117,8 @@ class KrgBased(SurrogateModel):
             theta = np.sum(self.optimal_theta * self.coeff_pls**2, axis=1)
         else:
             theta = self.optimal_theta
-        y = (df_dx[kx] + np.dot(dr[kx].T, gamma)) * self.y_std / self.X_scale[kx]
+
+        y = (df_dx[kx] + np.dot(drx, gamma)) * self.y_std / self.X_scale[kx]
         return y
 
     def _predict_variances(self, x):
@@ -1202,17 +1204,20 @@ class KrgBased(SurrogateModel):
         MSE[MSE < 0.0] = 0.0
         return MSE
 
-    def _predict_variance_derivatives(self, x):
+    def _predict_variance_derivatives(self, x, kx):
         """
         Provide the derivative of the variance of the model at a set of points
         Parameters
         -----------
         x : np.ndarray [n_evals, dim]
             Evaluation point input variable values
+        kx : int
+            The 0-based index of the input variable with respect to which derivatives are desired.
+
         Returns
         -------
          derived_variance:  np.ndarray
-             The jacobian of the variance of the kriging model
+             The jacobian of the variance of the kriging model (the kx-th derivative)
         """
 
         # Initialization
@@ -1234,9 +1239,13 @@ class KrgBased(SurrogateModel):
         r, dr = self._correlation_types[self.options["corr"]](
             theta, d, derivative_params=derivative_dic
         )
-        rt = linalg.solve_triangular(C, r, lower=True)
+        r = r.reshape(n_eval, self.nt)
+        drx = dr[:, kx]
+        drx = drx.reshape(n_eval, self.nt)
+
+        rt = linalg.solve_triangular(C, r.T, lower=True)
         invKr = linalg.solve_triangular(C.T, rt)
-        p1 = 2 * np.dot(dr.T, invKr).T
+        p1 = 2 * np.dot(drx, invKr).T
 
         # p2 : derivative of (u**2.0).sum(axis=0)
         f_x = self._regression_types[self.options["poly"]](x).T
@@ -1244,7 +1253,9 @@ class KrgBased(SurrogateModel):
         rho2 = linalg.solve_triangular(C, F, lower=True)
         invKF = linalg.solve_triangular(C.T, rho2)
 
-        A = f_x.T - np.dot(r.T, invKF)
+
+        A = f_x.T - np.dot(r, invKF)
+
         B = np.dot(F.T, invKF)
         rho3 = linalg.cholesky(B, lower=True)
         invBAt = linalg.solve_triangular(rho3, A.T, lower=True)
@@ -1261,20 +1272,17 @@ class KrgBased(SurrogateModel):
                 + "universal kriging using a linear trend"
             )
 
-        dA = df.T - np.dot(dr.T, invKF)
+        dA = df[:, kx].T - np.dot(drx, invKF)
         p3 = 2 * np.dot(dA, D).T
 
         # prime : derivative of MSE
         # MSE ~1.0 - (rt**2.0).sum(axis=0) + (u**2.0).sum(axis=0)
         prime = 0 - p1 + p3
         ## scaling factors
-        derived_variance = []
-        x_std = np.resize(self.X_scale, self.nx)
+        x_std = self.X_scale[kx]
+        derived_variance = np.array((np.outer(sigma2, np.diag(prime.T)) / x_std))
 
-        for i in range(len(x_std)):
-            derived_variance.append(sigma2 * prime.T[i] / x_std[i])
-
-        return np.array(derived_variance).T
+        return np.atleast_2d(derived_variance.T)
 
     def _optimize_hyperparam(self, D):
         """

--- a/smt/surrogate_models/surrogate_model.py
+++ b/smt/surrogate_models/surrogate_model.py
@@ -396,7 +396,7 @@ class SurrogateModel(metaclass=ABCMeta):
         s2 = self._predict_variances(x2)
         return s2.reshape((n, self.ny))
 
-    def predict_variance_derivatives(self, x):
+    def predict_variance_derivatives(self, x, kx):
         """
         Predict the derivation of the variance at a point
 
@@ -428,7 +428,7 @@ class SurrogateModel(metaclass=ABCMeta):
 
         # Evaluate the unknown points using the specified model-method
         with self.printer._timed_context("Predicting", key="prediction"):
-            y = self._predict_variance_derivatives(x)
+            y = self._predict_variance_derivatives(x, kx)
 
         time_pt = self.printer._time("prediction")[-1] / n
         self.printer()

--- a/smt/surrogate_models/tests/test_krg_outputs.py
+++ b/smt/surrogate_models/tests/test_krg_outputs.py
@@ -20,17 +20,16 @@ class TestKRG(unittest.TestCase):
             random_state=42,
         )
         x = sx(n)
-        
-        #2-dimensional output
-        n_s =2
+        # 2-dimensional output
+        n_s = 2
         sy = LHS(
-            xlimits=np.repeat(np.atleast_2d([0.0, 1.0]), n_s , axis=0),
+            xlimits=np.repeat(np.atleast_2d([0.0, 1.0]), n_s, axis=0),
             criterion="m",
             random_state=42,
         )
         y = sy(n)
 
-        kriging = KRG()
+        kriging = KRG(poly="linear")
         kriging.set_training_values(x, y)
         kriging.train()
 
@@ -40,12 +39,12 @@ class TestKRG(unittest.TestCase):
         var = kriging.predict_variances(x)
         self.assertEqual(y.shape, var.shape)
 
-        for kx in range(d) :
-            val_deriv = kriging.predict_derivatives(x,kx)
+        for kx in range(d):
+            val_deriv = kriging.predict_derivatives(x, kx)
             self.assertEqual(y.shape, val_deriv.shape)
-            var_deriv = kriging.predict_variance_derivatives(np.atleast_2d(x[0]))
-            self.assertEqual( (n_s,d)  ,var_deriv.shape)
-   
+            var_deriv = kriging.predict_variance_derivatives(x, 0)
+            self.assertEqual((n, n_s), var_deriv.shape)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/smt/surrogate_models/tests/test_krg_predictions.py
+++ b/smt/surrogate_models/tests/test_krg_predictions.py
@@ -51,7 +51,7 @@ class Test(SMTestCase):
         y_predicted = sm.predict_variances(self.xt)
         variance_at_training_inputs = np.sum(y_predicted**2)
 
-        np.testing.assert_allclose(variance_at_training_inputs, 0, atol=1e-5)
+        np.testing.assert_allclose(variance_at_training_inputs, 0, atol=1e-9)
 
     @staticmethod
     def _check_prediction_derivatives(self, sm):
@@ -68,7 +68,12 @@ class Test(SMTestCase):
         diff_g = (y_predicted[1, 0] - y_predicted[2, 0]) / (2 * e)
         diff_d = (y_predicted[3, 0] - y_predicted[4, 0]) / (2 * e)
 
-        deriv = sm.predict_variance_derivatives(x)
+        deriv = np.array(
+            [
+                sm.predict_variance_derivatives(x, 0)[0],
+                sm.predict_variance_derivatives(x, 1)[0],
+            ]
+        ).T
         pred_errors = np.array(
             [
                 np.abs((diff_g - deriv[0][0]) / diff_g),
@@ -76,7 +81,8 @@ class Test(SMTestCase):
             ]
         )
         total_error = np.sum(pred_errors**2)
-        np.testing.assert_allclose(total_error, 0, atol=5e-2)
+        
+        np.testing.assert_allclose(total_error, 0, atol=5e-3)
 
         y_predicted = sm.predict_values(x_valid)
 
@@ -95,7 +101,66 @@ class Test(SMTestCase):
         )
         total_error = np.sum(pred_errors**2)
 
-        np.testing.assert_allclose(total_error, 0, atol=1e-4)
+
+        np.testing.assert_allclose(total_error, 0, atol=1e-9)
+
+        ### VECTORIZATION TESTS
+
+        x_valid = np.concatenate(
+            (
+                x_valid,
+                np.atleast_2d(np.array([x_valid[0][0] + 1.0, x_valid[0][1] + 1.0])),
+            )
+        )
+
+        # test predict values & variances vectorization
+        all_vals1 = np.zeros((6, 2))
+        for i, x in enumerate(x_valid):
+            all_vals1[i, 0] = sm.predict_values(np.atleast_2d(x))
+            all_vals1[i, 1] = sm.predict_variances(np.atleast_2d(x))
+        all_vals2x = sm.predict_values(np.atleast_2d(x_valid)).flatten()
+        all_vals2y = sm.predict_variances(np.atleast_2d(x_valid)).flatten()
+        total_error = np.sum(
+            [
+                np.power(all_vals1[:, 0] - all_vals2x, 2),
+                np.power(all_vals1[:, 1] - all_vals2y, 2),
+            ]
+        )
+        np.testing.assert_allclose(total_error, 0, atol=1e-9)
+
+        # test predict_derivatives vectorization
+        all_vals1 = np.zeros((6, 2))
+        for i, x in enumerate(x_valid):
+            all_vals1[i, 0] = sm.predict_derivatives(np.atleast_2d(x), 0)
+            all_vals1[i, 1] = sm.predict_derivatives(np.atleast_2d(x), 1)
+        all_vals2x = sm.predict_derivatives(np.atleast_2d(x_valid), 0).flatten()
+        all_vals2y = sm.predict_derivatives(np.atleast_2d(x_valid), 1).flatten()
+        total_error = np.sum(
+            [
+                np.power(all_vals1[:, 0] - all_vals2x, 2),
+                np.power(all_vals1[:, 1] - all_vals2y, 2),
+            ]
+        )
+        np.testing.assert_allclose(total_error, 0, atol=1e-9)
+
+        # test predict_variance_derivatives vectorization
+        all_vals1 = np.zeros((6, 2))
+        for i, x in enumerate(x_valid):
+            all_vals1[i, 0] = sm.predict_variance_derivatives(np.atleast_2d(x), 0)
+            all_vals1[i, 1] = sm.predict_variance_derivatives(np.atleast_2d(x), 1)
+        all_vals2x = sm.predict_variance_derivatives(
+            np.atleast_2d(x_valid), 0
+        ).flatten()
+        all_vals2y = sm.predict_variance_derivatives(
+            np.atleast_2d(x_valid), 1
+        ).flatten()
+        total_error = np.sum(
+            [
+                np.power(all_vals1[:, 0] - all_vals2x, 2),
+                np.power(all_vals1[:, 1] - all_vals2y, 2),
+            ]
+        )
+        np.testing.assert_allclose(total_error, 0, atol=1e-9)
 
 
 if __name__ == "__main__":

--- a/smt/surrogate_models/tests/test_krg_predictions.py
+++ b/smt/surrogate_models/tests/test_krg_predictions.py
@@ -81,7 +81,7 @@ class Test(SMTestCase):
             ]
         )
         total_error = np.sum(pred_errors**2)
-        
+
         np.testing.assert_allclose(total_error, 0, atol=5e-3)
 
         y_predicted = sm.predict_values(x_valid)
@@ -100,7 +100,6 @@ class Test(SMTestCase):
             ]
         )
         total_error = np.sum(pred_errors**2)
-
 
         np.testing.assert_allclose(total_error, 0, atol=1e-9)
 

--- a/smt/surrogate_models/tests/test_krg_training.py
+++ b/smt/surrogate_models/tests/test_krg_training.py
@@ -265,16 +265,18 @@ class Test(SMTestCase):
             y_jacob = np.zeros((2, 5))
 
             for i in range(np.shape(x_valid)[0]):
-                l = kr.predict_variance_derivatives(np.atleast_2d(x_valid[i]))[0]
-                y_jacob[:, i] = l
+                l0 = kr.predict_variance_derivatives(np.atleast_2d(x_valid[i]), 0)[0]
+                l1 = kr.predict_variance_derivatives(np.atleast_2d(x_valid[i]), 1)[0]
+                y_jacob[0, i] = l0
+                y_jacob[1, i] = l1
 
-            diff_g = (y_predicted[1][0] - y_predicted[2][0]) / (2 * e)
-            diff_d = (y_predicted[3][0] - y_predicted[4][0]) / (2 * e)
+            diff_g = (y_predicted[1] - y_predicted[2]) / (2 * e)
+            diff_d = (y_predicted[3] - y_predicted[4]) / (2 * e)
 
-            jac_rel_error1 = abs((y_jacob[0] - diff_g) / y_jacob[0])
+            jac_rel_error1 = abs((y_jacob[0][0] - diff_g) / y_jacob[0][0])
             self.assert_error(jac_rel_error1, 1e-3, atol=0.01, rtol=0.01)
 
-            jac_rel_error2 = abs((y_jacob[1] - diff_d) / y_jacob[1])
+            jac_rel_error2 = abs((y_jacob[1][0] - diff_d) / y_jacob[1][1])
             self.assert_error(jac_rel_error2, 1e-3, atol=0.01, rtol=0.01)
 
 

--- a/smt/tests/test_array_outputs.py
+++ b/smt/tests/test_array_outputs.py
@@ -72,4 +72,4 @@ class ArrayOutputTest(SMTestCase):
 if __name__ == "__main__":
 
     xt, yt, sm = setup_sm("QP")
-# unittest.main()
+    unittest.main()


### PR DESCRIPTION
**Update derivative predictions:**
- Add vectorization for predict_variance_derivatives 
- Add component-wise derivatives
- Fix predict_derivatives vectorization bug (#389)
- Add vectorization tests and update the other tests 

**_**Special thanks to Inês Cardoso_**

**Clean EGO:**
- Add tests for qEI criteria and for SBO in EGO 
- Add tests for tunneling in EGO