### PR TITLE
Correct Gower distance bouds inconsistency & EGO for mixed integer

### DIFF
--- a/smt/applications/ego.py
+++ b/smt/applications/ego.py
@@ -374,19 +374,19 @@ class EGO(SurrogateBasedApplication):
             cons = []
             for j in range(len(bounds)):
                 lower, upper = bounds[j]
-                if isinstance(self.options["xtypes"][j], tuple):
-                    upper = int(upper - 1)
+                if self.options["categorical_kernel"] is not None:
+                    if isinstance(self.options["xtypes"][j], tuple):
+                        upper = int(upper - 1)
                 l = {"type": "ineq", "fun": lambda x, lb=lower, i=j: x[i] - lb}
                 u = {"type": "ineq", "fun": lambda x, ub=upper, i=j: ub - x[i]}
                 cons.append(l)
                 cons.append(u)
-                options = {"tol": 1e-6,"rhobeg":0.1}
+                options = {"catol": 1e-6, "tol": 1e-6, "rhobeg": 0.1}
         else:
             bounds = self.xlimits
             method = "SLSQP"
             cons = ()
             options = {"maxiter": 200}
-
 
         if criterion == "EI":
             self.obj_k = lambda x: -self.EI(np.atleast_2d(x), enable_tunneling, x_data)
@@ -436,6 +436,7 @@ class EGO(SurrogateBasedApplication):
         x_et_k = np.atleast_2d(opt["x"])
 
         return x_et_k, True
+
     def _get_virtual_point(self, x, y_data):
         """
         Depending on the qEI attribute return a predicted value at given point x

--- a/smt/applications/ego.py
+++ b/smt/applications/ego.py
@@ -428,7 +428,6 @@ class EGO(SurrogateBasedApplication):
             if not success:
                 self.log("New start point for the internal optimization")
                 n_optim += 1
-                n_start += 10
         if n_optim >= n_max_optim:
             # self.log("Internal optimization failed at EGO iter = {}".format(k))
             return np.atleast_2d(0), False

--- a/smt/applications/ego.py
+++ b/smt/applications/ego.py
@@ -381,8 +381,8 @@ class EGO(SurrogateBasedApplication):
                 u = {"type": "ineq", "fun": lambda x, ub=upper, i=j: ub - x[i]}
                 cons.append(l)
                 cons.append(u)
-                options = {"catol": 1e-6, "tol": 1e-6, "rhobeg": 0.1}
-                bounds = None
+            options = {"catol": 1e-6, "tol": 1e-6, "rhobeg": 0.1}
+            bounds = None
         else:
             bounds = self.xlimits
             method = "SLSQP"

--- a/smt/applications/ego.py
+++ b/smt/applications/ego.py
@@ -382,6 +382,7 @@ class EGO(SurrogateBasedApplication):
                 cons.append(l)
                 cons.append(u)
                 options = {"catol": 1e-6, "tol": 1e-6, "rhobeg": 0.1}
+                bounds = None
         else:
             bounds = self.xlimits
             method = "SLSQP"

--- a/smt/applications/ego.py
+++ b/smt/applications/ego.py
@@ -370,9 +370,10 @@ class EGO(SurrogateBasedApplication):
         n_max_optim = self.options["n_max_optim"]
         if self.mixint:
             bounds = self.mixint.get_unfolded_xlimits()
-            n_start += 10
+            method = "COBYLA"
         else:
             bounds = self.xlimits
+            method = "SLSQP"
 
         if criterion == "EI":
             self.obj_k = lambda x: -self.EI(np.atleast_2d(x), enable_tunneling, x_data)
@@ -392,7 +393,7 @@ class EGO(SurrogateBasedApplication):
                         minimize(
                             lambda x: float(np.array(self.obj_k(x)).flat[0]),
                             x_start[ii, :],
-                            method="SLSQP",
+                            method=method,
                             bounds=bounds,
                             options={"maxiter": 200},
                         )

--- a/smt/applications/ego.py
+++ b/smt/applications/ego.py
@@ -371,9 +371,17 @@ class EGO(SurrogateBasedApplication):
         if self.mixint:
             bounds = self.mixint.get_unfolded_xlimits()
             method = "COBYLA"
+            cons = []
+            for factor in range(len(bounds)):
+                lower, upper = bounds[factor]
+                l = {"type": "ineq", "fun": lambda x, lb=lower, i=factor: x[i] - lb}
+                u = {"type": "ineq", "fun": lambda x, ub=upper, i=factor: ub - x[i]}
+                cons.append(l)
+                cons.append(u)
         else:
             bounds = self.xlimits
             method = "SLSQP"
+            cons = ()
 
         if criterion == "EI":
             self.obj_k = lambda x: -self.EI(np.atleast_2d(x), enable_tunneling, x_data)
@@ -395,6 +403,7 @@ class EGO(SurrogateBasedApplication):
                             x_start[ii, :],
                             method=method,
                             bounds=bounds,
+                            constraints=cons,
                             options={"maxiter": 200},
                         )
                     )

--- a/smt/applications/mixed_integer.py
+++ b/smt/applications/mixed_integer.py
@@ -104,6 +104,8 @@ class MixedIntegerSurrogateModel(SurrogateModel):
         self._cat_kernel_comps = cat_kernel_comps
         self._xtypes = xtypes
         self._xlimits = xlimits
+        self._surrogate.options["xlimits"] = self._xlimits
+
         self._input_in_folded_space = input_in_folded_space
         self.supports = self._surrogate.supports
         self.options["print_global"] = False

--- a/smt/applications/tests/test_ego.py
+++ b/smt/applications/tests/test_ego.py
@@ -352,7 +352,7 @@ class TestEGO(SMTestCase):
             [[-5, 5], ["blue", "red", "green"], ["large", "small"], ["0", "2", "3"]],
             dtype="object",
         )
-        n_doe = 2
+        n_doe = 5
         sampling = MixedIntegerSamplingMethod(
             xtypes, xlimits, LHS, criterion="ese", random_state=42
         )
@@ -382,7 +382,7 @@ class TestEGO(SMTestCase):
             [[-5, 5], ["blue", "red", "green"], ["large", "small"], [0, 2]],
             dtype="object",
         )
-        n_doe = 2
+        n_doe = 5
         sampling = MixedIntegerSamplingMethod(
             xtypes,
             xlimits,
@@ -418,7 +418,7 @@ class TestEGO(SMTestCase):
             [[-5, 5], ["blue", "red", "green"], ["large", "small"], [0, 2]],
             dtype="object",
         )
-        n_doe = 2
+        n_doe = 5
         sampling = MixedIntegerSamplingMethod(
             xtypes,
             xlimits,

--- a/smt/applications/tests/test_mixed_integer.py
+++ b/smt/applications/tests/test_mixed_integer.py
@@ -428,7 +428,6 @@ class TestMixedInteger(unittest.TestCase):
             x1.append(np.array(element))
         x_pred = np.array(x1)
 
-
         y = sm.predict_values(x_pred)
         yvar = sm.predict_variances(x_pred)
 
@@ -506,7 +505,7 @@ class TestMixedInteger(unittest.TestCase):
         for element in itertools.product(x, x2):
             x1.append(np.array(element))
         x_pred = np.array(x1)
-     
+
         y = sm.predict_values(x_pred)
         yvar = sm.predict_variances(x_pred)
 

--- a/smt/applications/tests/test_mixed_integer.py
+++ b/smt/applications/tests/test_mixed_integer.py
@@ -428,10 +428,7 @@ class TestMixedInteger(unittest.TestCase):
             x1.append(np.array(element))
         x_pred = np.array(x1)
 
-        i = 0
-        for x in x_pred:
-            print(i, x)
-            i += 1
+
         y = sm.predict_values(x_pred)
         yvar = sm.predict_variances(x_pred)
 
@@ -471,10 +468,6 @@ class TestMixedInteger(unittest.TestCase):
             x1.append(np.array(element))
         x_pred = np.array(x1)
 
-        i = 0
-        for x in x_pred:
-            print(i, x)
-            i += 1
         y = sm.predict_values(x_pred)
         yvar = sm.predict_variances(x_pred)
 
@@ -513,11 +506,7 @@ class TestMixedInteger(unittest.TestCase):
         for element in itertools.product(x, x2):
             x1.append(np.array(element))
         x_pred = np.array(x1)
-
-        i = 0
-        for x in x_pred:
-            print(i, x)
-            i += 1
+     
         y = sm.predict_values(x_pred)
         yvar = sm.predict_variances(x_pred)
 
@@ -684,10 +673,6 @@ class TestMixedInteger(unittest.TestCase):
             x1.append(np.array(element))
         x_pred = np.array(x1)
 
-        i = 0
-        for x in x_pred:
-            print(i, x)
-            i += 1
         y = sm.predict_values(x_pred)
         yvar = sm.predict_variances(x_pred)
 

--- a/smt/applications/tests/test_mixed_integer.py
+++ b/smt/applications/tests/test_mixed_integer.py
@@ -678,20 +678,21 @@ class TestMixedInteger(unittest.TestCase):
         # prediction are correct on known points
         self.assertTrue((np.abs(np.sum(np.array(sm.predict_values(xt) - yt)) < 1e-6)))
         self.assertTrue((np.abs(np.sum(np.array(sm.predict_variances(xt) - 0)) < 1e-6)))
-   
+
         def test_mixed_gower_3D(self):
             from smt.problems import Sphere
             from smt.sampling_methods import LHS
-            from smt.surrogate_models import KRG, QP, FLOAT, ENUM, ORD,GOWER_KERNEL
-            
-            
-            xtypes = [FLOAT, ORD,ORD]
+            from smt.surrogate_models import KRG, QP, FLOAT, ENUM, ORD, GOWER_KERNEL
+
+            xtypes = [FLOAT, ORD, ORD]
             xlimits = [[-10, 10], [-10, 10], [-10, 10]]
-            mixint = MixedIntegerContext(xtypes, xlimits,    categorical_kernel=GOWER_KERNEL)
-            
+            mixint = MixedIntegerContext(
+                xtypes, xlimits, categorical_kernel=GOWER_KERNEL
+            )
+
             sm = mixint.build_surrogate_model(KRG(print_prediction=False))
             sampling = mixint.build_sampling_method(LHS, criterion="m")
-            
+
             fun = Sphere(ndim=3)
             xt = sampling(10)
             yt = fun(xt)
@@ -702,6 +703,7 @@ class TestMixedInteger(unittest.TestCase):
                 if abs(float(xt[i, :][1]) - int(float(xt[i, :][1]))) > 10e-8:
                     eq_check = False
             self.assertTrue(eq_check)
+
     def test_mixed_gower(self):
         import numpy as np
         import matplotlib.pyplot as plt

--- a/smt/applications/tests/test_mixed_integer.py
+++ b/smt/applications/tests/test_mixed_integer.py
@@ -678,7 +678,30 @@ class TestMixedInteger(unittest.TestCase):
         # prediction are correct on known points
         self.assertTrue((np.abs(np.sum(np.array(sm.predict_values(xt) - yt)) < 1e-6)))
         self.assertTrue((np.abs(np.sum(np.array(sm.predict_variances(xt) - 0)) < 1e-6)))
-
+   
+        def test_mixed_gower_3D(self):
+            from smt.problems import Sphere
+            from smt.sampling_methods import LHS
+            from smt.surrogate_models import KRG, QP, FLOAT, ENUM, ORD,GOWER_KERNEL
+            
+            
+            xtypes = [FLOAT, ORD,ORD]
+            xlimits = [[-10, 10], [-10, 10], [-10, 10]]
+            mixint = MixedIntegerContext(xtypes, xlimits,    categorical_kernel=GOWER_KERNEL)
+            
+            sm = mixint.build_surrogate_model(KRG(print_prediction=False))
+            sampling = mixint.build_sampling_method(LHS, criterion="m")
+            
+            fun = Sphere(ndim=3)
+            xt = sampling(10)
+            yt = fun(xt)
+            sm.set_training_values(xt, yt)
+            sm.train()
+            eq_check = True
+            for i in range(xt.shape[0]):
+                if abs(float(xt[i, :][1]) - int(float(xt[i, :][1]))) > 10e-8:
+                    eq_check = False
+            self.assertTrue(eq_check)
     def test_mixed_gower(self):
         import numpy as np
         import matplotlib.pyplot as plt

--- a/smt/surrogate_models/krg_based.py
+++ b/smt/surrogate_models/krg_based.py
@@ -89,7 +89,7 @@ class KrgBased(SurrogateModel):
         declare(
             "xlimits",
             None,
-            desc='the upper and lower var bounds.',
+            desc="the upper and lower var bounds.",
         )
         declare(
             "xtypes",
@@ -1008,7 +1008,10 @@ class KrgBased(SurrogateModel):
         n_eval, n_features_x = x.shape
         if self.options["categorical_kernel"] is not None:
             dx = gower_componentwise_distances(
-                x, y=np.copy(self.X_train), xlimits=self.options["xlimits"], xtypes=self.options["xtypes"]
+                x,
+                y=np.copy(self.X_train),
+                xlimits=self.options["xlimits"],
+                xtypes=self.options["xtypes"],
             )
 
             d = componentwise_distance(
@@ -1143,7 +1146,10 @@ class KrgBased(SurrogateModel):
         if self.options["categorical_kernel"] is not None:
 
             dx = gower_componentwise_distances(
-                x, y=np.copy(self.X_train), xlimits=self.options["xlimits"], xtypes=self.options["xtypes"]
+                x,
+                y=np.copy(self.X_train),
+                xlimits=self.options["xlimits"],
+                xtypes=self.options["xtypes"],
             )
             d = componentwise_distance(
                 dx,

--- a/smt/surrogate_models/krg_based.py
+++ b/smt/surrogate_models/krg_based.py
@@ -86,7 +86,11 @@ class KrgBased(SurrogateModel):
             ],
             desc="The kernel to use for categorical inputs. Only for non continuous Kriging",
         )
-
+        declare(
+            "xlimits",
+            None,
+            desc='the upper and lower var bounds.',
+        )
         declare(
             "xtypes",
             None,
@@ -173,7 +177,7 @@ class KrgBased(SurrogateModel):
 
         if self.options["categorical_kernel"] is not None:
             D, self.ij, X = gower_componentwise_distances(
-                X=X, xtypes=self.options["xtypes"]
+                X=X, xlimits=self.options["xlimits"], xtypes=self.options["xtypes"]
             )
             self.Lij, self.n_levels = cross_levels(
                 X=self.X_train, ij=self.ij, xtypes=self.options["xtypes"]
@@ -1004,7 +1008,7 @@ class KrgBased(SurrogateModel):
         n_eval, n_features_x = x.shape
         if self.options["categorical_kernel"] is not None:
             dx = gower_componentwise_distances(
-                x, y=np.copy(self.X_train), xtypes=self.options["xtypes"]
+                x, y=np.copy(self.X_train), xlimits=self.options["xlimits"], xtypes=self.options["xtypes"]
             )
 
             d = componentwise_distance(
@@ -1139,7 +1143,7 @@ class KrgBased(SurrogateModel):
         if self.options["categorical_kernel"] is not None:
 
             dx = gower_componentwise_distances(
-                x, y=np.copy(self.X_train), xtypes=self.options["xtypes"]
+                x, y=np.copy(self.X_train), xlimits=self.options["xlimits"], xtypes=self.options["xtypes"]
             )
             d = componentwise_distance(
                 dx,

--- a/smt/surrogate_models/ls.py
+++ b/smt/surrogate_models/ls.py
@@ -28,7 +28,11 @@ class LS(SurrogateModel):
         super(LS, self)._initialize()
         declare = self.options.declare
         supports = self.supports
-
+        declare(
+            "xlimits",
+            None,
+            desc='the upper and lower var bounds.',
+        )
         declare(
             "data_dir",
             values=None,

--- a/smt/surrogate_models/ls.py
+++ b/smt/surrogate_models/ls.py
@@ -31,7 +31,7 @@ class LS(SurrogateModel):
         declare(
             "xlimits",
             None,
-            desc='the upper and lower var bounds.',
+            desc="the upper and lower var bounds.",
         )
         declare(
             "data_dir",

--- a/smt/surrogate_models/qp.py
+++ b/smt/surrogate_models/qp.py
@@ -28,7 +28,7 @@ class QP(SurrogateModel):
         declare(
             "xlimits",
             None,
-            desc='the upper and lower var bounds.',
+            desc="the upper and lower var bounds.",
         )
         declare(
             "data_dir",

--- a/smt/surrogate_models/qp.py
+++ b/smt/surrogate_models/qp.py
@@ -25,7 +25,11 @@ class QP(SurrogateModel):
         super(QP, self)._initialize()
         declare = self.options.declare
         supports = self.supports
-
+        declare(
+            "xlimits",
+            None,
+            desc='the upper and lower var bounds.',
+        )
         declare(
             "data_dir",
             values=None,

--- a/smt/utils/kriging_utils.py
+++ b/smt/utils/kriging_utils.py
@@ -238,7 +238,7 @@ def compute_X_cont(x, xtypes):
     return x[:, np.logical_not(cat_features)], cat_features
 
 
-def gower_componentwise_distances(X, xlimits,  y=None, xtypes=None):
+def gower_componentwise_distances(X, xlimits, y=None, xtypes=None):
     """
     Computes the nonzero Gower-distances componentwise between the vectors
     in X.
@@ -298,14 +298,15 @@ def gower_componentwise_distances(X, xlimits,  y=None, xtypes=None):
     lim = np.atleast_2d(np.array(xlimits, dtype=object)[np.logical_not(cat_features)])
     lb = np.zeros(np.shape(lim)[1])
     ub = np.zeros(np.shape(lim)[1])
-    for k,i in enumerate(lim[0]) :
-        lb[k]= i[0]
-        ub[k]= i[-1]
-    Z_offset =lb
-    Z_max = ub
-    Z_scale = Z_max - Z_offset
-    Z_num = (Z_num-Z_offset)/Z_scale
-    
+    if np.shape(lim)[0] > 0:
+        for k, i in enumerate(lim[0]):
+            lb[k] = i[0]
+            ub[k] = i[-1]
+        Z_offset = lb
+        Z_max = ub
+        Z_scale = Z_max - Z_offset
+        Z_num = (Z_num - Z_offset) / Z_scale
+
     num_cols = Z_num.shape[1]
     num_ranges = np.zeros(num_cols)
     num_max = np.zeros(num_cols)

--- a/smt/utils/kriging_utils.py
+++ b/smt/utils/kriging_utils.py
@@ -293,11 +293,11 @@ def gower_componentwise_distances(X, xlimits, y=None, xtypes=None):
     Z_num = Z[:, np.logical_not(cat_features)]
 
     # This is to normalize the numeric values between 0 and 1.
-    lim = np.atleast_2d(np.array(xlimits, dtype=object)[np.logical_not(cat_features)])
-    lb = np.zeros(np.shape(lim)[1])
-    ub = np.zeros(np.shape(lim)[1])
+    lim = np.array(xlimits, dtype=object)[np.logical_not(cat_features)]
+    lb = np.zeros(np.shape(lim)[0])
+    ub = np.ones(np.shape(lim)[0])
     if np.shape(lim)[0] > 0:
-        for k, i in enumerate(lim[0]):
+        for k, i in enumerate(lim):
             lb[k] = i[0]
             ub[k] = i[-1]
         Z_offset = lb

--- a/smt/utils/kriging_utils.py
+++ b/smt/utils/kriging_utils.py
@@ -307,10 +307,6 @@ def gower_componentwise_distances(X, xlimits, y=None, xtypes=None):
         Z_scale = Z_max - Z_offset
         Z_num = (Z_num - Z_offset) / Z_scale
 
-    num_cols = Z_num.shape[1]
-    num_ranges = np.zeros(num_cols)
-    num_max = np.zeros(num_cols)
-
     Z_cat = Z[:, cat_features]
 
     X_cat = Z_cat[

--- a/smt/utils/kriging_utils.py
+++ b/smt/utils/kriging_utils.py
@@ -307,7 +307,7 @@ def gower_componentwise_distances(X, y=None, xtypes=None):
             min = 0.0
         num_max[col] = max
         num_ranges[col] = (1 - min / max) if (max != 0) else 0.0
-
+        num_ranges[col] = 1
     # This is to normalize the numeric values between 0 and 1.
     Z_num = np.divide(Z_num, num_max, out=np.zeros_like(Z_num), where=num_max != 0)
 

--- a/smt/utils/kriging_utils.py
+++ b/smt/utils/kriging_utils.py
@@ -232,8 +232,7 @@ def compute_X_cont(x, xtypes):
     if xtypes is None:
         return x, None
     cat_features = [
-        not (xtype == "float_type" or xtype == "ord_type")
-        for i, xtype in enumerate(xtypes)
+        not (xtype == "float_type" or xtype == "ord_type") for xtype in xtypes
     ]
     return x[:, np.logical_not(cat_features)], cat_features
 

--- a/smt/utils/kriging_utils.py
+++ b/smt/utils/kriging_utils.py
@@ -238,7 +238,7 @@ def compute_X_cont(x, xtypes):
     return x[:, np.logical_not(cat_features)], cat_features
 
 
-def gower_componentwise_distances(X, y=None, xtypes=None):
+def gower_componentwise_distances(X, xlimits,  y=None, xtypes=None):
     """
     Computes the nonzero Gower-distances componentwise between the vectors
     in X.
@@ -248,6 +248,8 @@ def gower_componentwise_distances(X, y=None, xtypes=None):
             - The input variables.
     y: np.ndarray [n_y, dim]
             - The training data.
+    xlimits: np.ndarray[dim, 2]
+            - The upper and lower var bounds.
     xtypes: np.ndarray [dim]
             -the types (FLOAT,ORD,ENUM) of the input variables
     Returns
@@ -293,13 +295,20 @@ def gower_componentwise_distances(X, y=None, xtypes=None):
     Y_num = Y[:, np.logical_not(cat_features)]
 
     # This is to normalize the numeric values between 0 and 1.
-    Z_offset = np.min(Z_num, axis=0)
-    Z_max = np.max(Z_num, axis=0)
+    lim = np.atleast_2d(np.array(xlimits, dtype=object)[np.logical_not(cat_features)])
+    lb = np.zeros(np.shape(lim)[1])
+    ub = np.zeros(np.shape(lim)[1])
+    for k,i in enumerate(lim[0]) :
+        lb[k]= i[0]
+        ub[k]= i[-1]
+    Z_offset =lb
+    Z_max = ub
     Z_scale = Z_max - Z_offset
     Z_num = (Z_num-Z_offset)/Z_scale
     
     num_cols = Z_num.shape[1]
-    num_ranges = np.ones(num_cols)
+    num_ranges = np.zeros(num_cols)
+    num_max = np.zeros(num_cols)
 
     Z_cat = Z[:, cat_features]
 

--- a/smt/utils/kriging_utils.py
+++ b/smt/utils/kriging_utils.py
@@ -292,7 +292,6 @@ def gower_componentwise_distances(X, xlimits, y=None, xtypes=None):
     y_index = range(x_n_rows, x_n_rows + y_n_rows)
 
     Z_num = Z[:, np.logical_not(cat_features)]
-    Y_num = Y[:, np.logical_not(cat_features)]
 
     # This is to normalize the numeric values between 0 and 1.
     lim = np.atleast_2d(np.array(xlimits, dtype=object)[np.logical_not(cat_features)])
@@ -322,8 +321,8 @@ def gower_componentwise_distances(X, xlimits, y=None, xtypes=None):
         y_index,
     ]
 
-    X_norma = X
-    Y_norma = Y
+    X_norma = np.copy(X)
+    Y_norma = np.copy(Y)
     X_norma[:, np.logical_not(cat_features)] = X_num
     Y_norma[:, np.logical_not(cat_features)] = Y_num
 


### PR DESCRIPTION
- There was both an inconsistency for the data normalization within Gower distance and a problem as the data were not in [0,1] as intended.  
This PR correct this error by using directly the bounds of the variables (xlimits) and by doing a proper job to project the data into [0,1]^n. 

- The  Acquisition criterion was not maximized at all with Mixed-integer variables. Now, it is maximized from random starting points by CObyLA. 

Fix several bugs. 