### PR TITLE
Refactor XSpecs for stronger typing

### DIFF
--- a/doc/_src_docs/applications/mixed_integer.rstx
+++ b/doc/_src_docs/applications/mixed_integer.rstx
@@ -93,7 +93,7 @@ With this distance, a mixed integer kernel can be build. Details can be found in
 Example of mixed-integer Gower Distance model
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. embed-test-print-plot :: smt.applications.tests.test_mixed_integer , TestMixedInteger , test_mixed_gower, 80	
+.. embed-test-print-plot :: smt.applications.tests.test_mixed_integer , TestMixedInteger , run_mixed_gower_example, 80	
 
 
 
@@ -103,9 +103,9 @@ Mixed-Integer Surrogate with Group Kernel (Homoscedastic Hypersphere)
 This surrogate model consider that the correlation kernel between the levels of a given variable is a symmetric positive definite matrix. The latter matrix is estimated through an hypersphere parametrization depending on several hyperparameters. To finish with, the data correlation matrix is build as the product of the correlation matrices over the various variables. Details can be found in [1]_ . Note that this model is the only one to consider negative correlations between levels ("blue" can be correlated negatively to "red").
 
 Example of mixed-integer Homoscedastic Hypersphere model
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. embed-test-print-plot :: smt.applications.tests.test_mixed_integer , TestMixedInteger , test_mixed_homo_hyp, 80	
+.. embed-test-print-plot :: smt.applications.tests.test_mixed_integer , TestMixedInteger , run_mixed_homo_hyp_example, 80	
  	
 
 Mixed-Integer Surrogate with Exponential Homoscedastic Hypersphere
@@ -116,7 +116,7 @@ This surrogate model also consider that the correlation kernel between the level
 Example of mixed-integer Exponential Homoscedastic Hypersphere model
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. embed-test-print-plot :: smt.applications.tests.test_mixed_integer , TestMixedInteger , test_mixed_homo_gaussian, 80	
+.. embed-test-print-plot :: smt.applications.tests.test_mixed_integer , TestMixedInteger , run_mixed_homo_gaussian_example, 80	
 
 
 References

--- a/smt/applications/tests/test_ego.py
+++ b/smt/applications/tests/test_ego.py
@@ -68,9 +68,7 @@ class TestEGO(SMTestCase):
         n_iter = 15
         xlimits = np.array([[0.0, 25.0]])
         criterion = "EI"
-        xspecs = XSpecs()
-
-        xspecs["xlimits"] = xlimits
+        xspecs = XSpecs(xlimits=xlimits)
 
         ego = EGO(
             n_iter=n_iter,
@@ -88,9 +86,7 @@ class TestEGO(SMTestCase):
     def test_function_test_1d_parallel(self):
         n_iter = 3
         xlimits = np.array([[0.0, 25.0]])
-        xspecs = XSpecs()
-
-        xspecs["xlimits"] = xlimits
+        xspecs = XSpecs(xlimits=xlimits)
 
         criterion = "EI"
         n_parallel = 3
@@ -115,9 +111,7 @@ class TestEGO(SMTestCase):
         fun = Rosenbrock(ndim=2)
         xlimits = fun.xlimits
         criterion = "LCB"  #'EI' or 'SBO' or 'LCB'
-        xspecs = XSpecs()
-
-        xspecs["xlimits"] = xlimits
+        xspecs = XSpecs(xlimits=xlimits)
 
         xdoe = FullFactorial(xlimits=xlimits)(10)
         ego = EGO(
@@ -137,9 +131,7 @@ class TestEGO(SMTestCase):
         fun = Rosenbrock(ndim=2)
         xlimits = fun.xlimits
         criterion = "SBO"  #'EI' or 'SBO' or 'LCB'
-        xspecs = XSpecs()
-
-        xspecs["xlimits"] = xlimits
+        xspecs = XSpecs(xlimits=xlimits)
 
         xdoe = FullFactorial(xlimits=xlimits)(50)
         ego = EGO(
@@ -161,9 +153,7 @@ class TestEGO(SMTestCase):
         fun = Rosenbrock(ndim=2)
         xlimits = fun.xlimits
         criterion = "LCB"  #'EI' or 'SBO' or 'LCB'
-        xspecs = XSpecs()
-
-        xspecs["xlimits"] = xlimits
+        xspecs = XSpecs(xlimits=xlimits)
 
         xdoe = FullFactorial(xlimits=xlimits)(10)
         qEI = "KB"
@@ -187,11 +177,7 @@ class TestEGO(SMTestCase):
         n_iter = 20
         fun = Branin(ndim=2)
         criterion = "LCB"  #'EI' or 'SBO' or 'LCB'
-        xspecs = XSpecs()
-
-        xspecs["xlimits"] = fun.xlimits
-
-        xdoe = FullFactorial(xlimits=fun.xlimits)(15)
+        xspecs = XSpecs(xlimits=fun.xlimits)
         ego = EGO(
             surrogate=KRG(xspecs=xspecs, print_global=False),
             n_iter=n_iter,
@@ -215,9 +201,7 @@ class TestEGO(SMTestCase):
         n_parallel = 5
         xlimits = fun.xlimits
         criterion = "EI"  #'EI' or 'SBO' or 'LCB'
-        xspecs = XSpecs()
-
-        xspecs["xlimits"] = xlimits
+        xspecs = XSpecs(xlimits=xlimits)
 
         xdoe = FullFactorial(xlimits=xlimits)(10)
         ego = EGO(
@@ -249,14 +233,10 @@ class TestEGO(SMTestCase):
         criterion = "EI"  #'EI' or 'SBO' or 'LCB'
         qEI = "CLmin"
         xtypes = [ORD, FLOAT]
-        xspecs = XSpecs()
-
-        xspecs["xtypes"] = xtypes
-        xspecs["xlimits"] = xlimits
-
+        xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
         sm = KRG(xspecs=xspecs, print_global=False)
         mixint = MixedIntegerContext(xspecs)
-        sampling = mixint.build_sampling_method(FullFactorial, xspecs=xspecs)
+        sampling = mixint.build_sampling_method(FullFactorial)
         xdoe = sampling(10)
 
         ego = EGO(
@@ -285,11 +265,7 @@ class TestEGO(SMTestCase):
         fun = Branin(ndim=2)
         xtypes = [ORD, FLOAT]
         xlimits = fun.xlimits
-        xspecs = XSpecs()
-
-        xspecs["xtypes"] = xtypes
-        xspecs["xlimits"] = xlimits
-
+        xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
         criterion = "EI"  #'EI' or 'SBO' or 'LCB'
 
         sm = KRG(xspecs=xspecs, print_global=False)
@@ -320,10 +296,7 @@ class TestEGO(SMTestCase):
         fun = Branin(ndim=2)
         xtypes = [ORD, FLOAT]
         xlimits = fun.xlimits
-        xspecs = XSpecs()
-
-        xspecs["xtypes"] = xtypes
-        xspecs["xlimits"] = xlimits
+        xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
         criterion = "EI"  #'EI' or 'SBO' or 'LCB'
 
         sm = KRG(xspecs=xspecs, print_global=False)
@@ -381,11 +354,7 @@ class TestEGO(SMTestCase):
             [[-5, 5], ["blue", "red", "green"], ["large", "small"], ["0", "2", "3"]],
             dtype="object",
         )
-        xspecs = XSpecs()
-
-        xspecs["xtypes"] = xtypes
-        xspecs["xlimits"] = xlimits
-
+        xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
         n_doe = 5
         sampling = MixedIntegerSamplingMethod(
             LHS, xspecs, criterion="ese", random_state=42
@@ -412,10 +381,7 @@ class TestEGO(SMTestCase):
             [[-5, 5], ["blue", "red", "green"], ["large", "small"], [0, 2]],
             dtype="object",
         )
-        xspecs = XSpecs()
-
-        xspecs["xtypes"] = xtypes
-        xspecs["xlimits"] = xlimits
+        xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
         n_doe = 5
         sampling = MixedIntegerSamplingMethod(
             LHS,
@@ -430,10 +396,11 @@ class TestEGO(SMTestCase):
             n_iter=n_iter,
             criterion=criterion,
             xdoe=xdoe,
-            surrogate=KRG(xspecs=xspecs, print_global=False),
+            surrogate=KRG(
+                xspecs=xspecs, categorical_kernel=GOWER_KERNEL, print_global=False
+            ),
             enable_tunneling=False,
             random_state=42,
-            categorical_kernel=GOWER_KERNEL,
         )
         _, y_opt, _, _, _ = ego.optimize(fun=TestEGO.function_test_mixed_integer)
 
@@ -447,10 +414,7 @@ class TestEGO(SMTestCase):
             [[-5, 5], ["blue", "red", "green"], ["large", "small"], [0, 2]],
             dtype="object",
         )
-        xspecs = XSpecs()
-
-        xspecs["xtypes"] = xtypes
-        xspecs["xlimits"] = xlimits
+        xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
         n_doe = 5
         sampling = MixedIntegerSamplingMethod(
             LHS,
@@ -466,10 +430,13 @@ class TestEGO(SMTestCase):
             n_iter=n_iter,
             criterion=criterion,
             xdoe=xdoe,
-            surrogate=KRG(xspecs=xspecs, print_global=False),
+            surrogate=KRG(
+                xspecs=xspecs,
+                categorical_kernel=EXP_HOMO_HSPHERE_KERNEL,
+                print_global=False,
+            ),
             enable_tunneling=False,
             random_state=42,
-            categorical_kernel=EXP_HOMO_HSPHERE_KERNEL,
         )
         _, y_opt, _, _, _ = ego.optimize(fun=TestEGO.function_test_mixed_integer)
 
@@ -483,11 +450,7 @@ class TestEGO(SMTestCase):
             [[-5, 5], ["blue", "red", "green"], ["large", "small"], [0, 2]],
             dtype="object",
         )
-        xspecs = XSpecs()
-
-        xspecs["xtypes"] = xtypes
-        xspecs["xlimits"] = xlimits
-        n_doe = 7
+        xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
         sampling = MixedIntegerSamplingMethod(
             LHS,
             xspecs,
@@ -495,11 +458,16 @@ class TestEGO(SMTestCase):
             random_state=42,
             output_in_folded_space=True,
         )
+        n_doe = 5
         xdoe = sampling(n_doe)
         criterion = "EI"  #'EI' or 'SBO' or 'LCB'
-        sm = KPLS(print_global=False, xspecs=xspecs, n_comp=1, cat_kernel_comps=[2, 2])
-        mixint = MixedIntegerContext(xspecs)
-
+        sm = KPLS(
+            print_global=False,
+            xspecs=xspecs,
+            categorical_kernel=EXP_HOMO_HSPHERE_KERNEL,
+            n_comp=1,
+            cat_kernel_comps=[2, 2],
+        )
         ego = EGO(
             n_iter=n_iter,
             criterion=criterion,
@@ -507,7 +475,6 @@ class TestEGO(SMTestCase):
             surrogate=sm,
             enable_tunneling=False,
             random_state=42,
-            categorical_kernel=EXP_HOMO_HSPHERE_KERNEL,
         )
         _, y_opt, _, _, _ = ego.optimize(fun=TestEGO.function_test_mixed_integer)
 
@@ -518,9 +485,7 @@ class TestEGO(SMTestCase):
         fun = Branin(ndim=2)
         xlimits = fun.xlimits
         criterion = "LCB"  #'EI' or 'SBO' or 'LCB'
-        xspecs = XSpecs()
-
-        xspecs["xlimits"] = xlimits
+        xspecs = XSpecs(xlimits=xlimits)
         xdoe = FullFactorial(xlimits=xlimits)(10)
         ydoe = fun(xdoe)
 
@@ -539,9 +504,7 @@ class TestEGO(SMTestCase):
     def test_find_best_point(self):
         fun = TestEGO.function_test_1d
         xlimits = np.array([[0.0, 25.0]])
-        xspecs = XSpecs()
-
-        xspecs["xlimits"] = xlimits
+        xspecs = XSpecs(xlimits=xlimits)
         xdoe = FullFactorial(xlimits=xlimits)(3)
         ydoe = fun(xdoe)
         ego = EGO(
@@ -576,9 +539,8 @@ class TestEGO(SMTestCase):
                 return np.hstack((response, sens))
 
         fun = TensorProductIndirect(ndim=2, func=func)
-        xspecs = XSpecs()
+        xspecs = XSpecs(xlimits=fun.xlimits)
 
-        xspecs["xlimits"] = fun.xlimits
         # Construction of the DOE
         sampling = LHS(xlimits=fun.xlimits, criterion="m", random_state=42)
         xdoe = sampling(20)
@@ -629,9 +591,7 @@ class TestEGO(SMTestCase):
     def test_qei_criterion_default(self):
         fun = TestEGO.function_test_1d
         xlimits = np.array([[0.0, 25.0]])
-        xspecs = XSpecs()
-
-        xspecs["xlimits"] = xlimits
+        xspecs = XSpecs(xlimits=xlimits)
         xdoe = FullFactorial(xlimits=xlimits)(3)
         ydoe = fun(xdoe)
         ego = EGO(
@@ -672,9 +632,7 @@ class TestEGO(SMTestCase):
 
         n_iter = 6
         xlimits = np.array([[0.0, 25.0]])
-        xspecs = XSpecs()
-
-        xspecs["xlimits"] = xlimits
+        xspecs = XSpecs(xlimits=xlimits)
         xdoe = np.atleast_2d([0, 7, 25]).T
         n_doe = xdoe.size
 
@@ -787,10 +745,7 @@ class TestEGO(SMTestCase):
             [[-5, 5], ["red", "green", "blue"], ["square", "circle"], [0, 2]],
             dtype="object",
         )
-        xspecs = XSpecs()
-
-        xspecs["xtypes"] = xtypes
-        xspecs["xlimits"] = xlimits
+        xspecs = XSpecs(xtypes=xtypes, limits=xlimits)
 
         criterion = "EI"  #'EI' or 'SBO' or 'LCB'
         qEI = "KBRand"
@@ -858,9 +813,7 @@ class TestEGO(SMTestCase):
         n_parallel = 3
         n_start = 50
         xlimits = np.array([[0.0, 25.0]])
-        xspecs = XSpecs()
-
-        xspecs["xlimits"] = xlimits
+        xspecs = XSpecs(xlimits=xlimits)
         xdoe = np.atleast_2d([0, 7, 25]).T
         n_doe = xdoe.size
 

--- a/smt/applications/tests/test_mixed_integer.py
+++ b/smt/applications/tests/test_mixed_integer.py
@@ -1,6 +1,7 @@
 import unittest
 import numpy as np
 import matplotlib
+import itertools
 
 matplotlib.use("Agg")
 
@@ -22,7 +23,19 @@ from smt.utils.mixed_integer import (
 )
 from smt.problems import Sphere
 from smt.sampling_methods import LHS
-from smt.surrogate_models import KRG, QP, FLOAT, ENUM, ORD
+from smt.surrogate_models import (
+    KRG,
+    KPLS,
+    QP,
+    FLOAT,
+    ENUM,
+    ORD,
+    XSpecs,
+    GOWER_KERNEL,
+    HOMO_HSPHERE_KERNEL,
+    EXP_HOMO_HSPHERE_KERNEL,
+)
+from smt.applications.mixed_integer import MixedIntegerKrigingModel
 
 
 class TestMixedInteger(unittest.TestCase):
@@ -284,12 +297,18 @@ class TestMixedInteger(unittest.TestCase):
             True,
         )
 
+    def test_examples(self):
+        self.run_mixed_integer_lhs_example()
+        self.run_mixed_integer_qp_example()
+        self.run_mixed_integer_context_example()
+
     def run_mixed_integer_lhs_example(self):
         import numpy as np
         import matplotlib.pyplot as plt
         from matplotlib import colors
 
-        from smt.sampling_methods import LHS, FLOAT, ENUM
+        from smt.sampling_methods import LHS
+        from smt.surrogate_models import FLOAT, ENUM, XSpecs
         from smt.applications.mixed_integer import MixedIntegerSamplingMethod
 
         xtypes = [FLOAT, (ENUM, 2)]
@@ -309,7 +328,7 @@ class TestMixedInteger(unittest.TestCase):
         import numpy as np
         import matplotlib.pyplot as plt
 
-        from smt.surrogate_models import QP, ORD
+        from smt.surrogate_models import QP, ORD, XSpecs
         from smt.applications.mixed_integer import MixedIntegerSurrogateModel
 
         xt = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
@@ -343,7 +362,7 @@ class TestMixedInteger(unittest.TestCase):
         from mpl_toolkits.mplot3d import Axes3D
 
         from smt.sampling_methods import LHS, Random
-        from smt.surrogate_models import KRG, FLOAT, ORD, ENUM
+        from smt.surrogate_models import KRG, FLOAT, ORD, ENUM, XSpecs
         from smt.applications.mixed_integer import MixedIntegerContext
 
         xtypes = [ORD, FLOAT, (ENUM, 4)]
@@ -383,13 +402,6 @@ class TestMixedInteger(unittest.TestCase):
         plt.show()
 
     def test_mixed_gower_2D(self):
-        import matplotlib.pyplot as plt
-        import numpy as np
-        import itertools
-
-        from smt.surrogate_models import KRG, ENUM, FLOAT, GOWER_KERNEL
-        from smt.applications.mixed_integer import MixedIntegerKrigingModel
-
         xt = np.array([[0, 5], [2, -1], [4, 0.5]])
         yt = np.array([[0.0], [1.0], [1.5]])
         xlimits = [["0.0", "1.0", " 2.0", "3.0", "4.0"], [-5, 5]]
@@ -426,13 +438,6 @@ class TestMixedInteger(unittest.TestCase):
         self.assertEqual(np.shape(y), (105, 1))
 
     def test_mixed_homo_gaussian_2D(self):
-        import matplotlib.pyplot as plt
-        import numpy as np
-        import itertools
-
-        from smt.surrogate_models import KRG, ENUM, FLOAT, EXP_HOMO_HSPHERE_KERNEL
-        from smt.applications.mixed_integer import MixedIntegerKrigingModel
-
         xt = np.array([[0, 5], [2, -1], [4, 0.5]])
         yt = np.array([[0.0], [1.0], [1.5]])
         xlimits = [["0.0", "1.0", " 2.0", "3.0", "4.0"], [-5, 5]]
@@ -468,13 +473,6 @@ class TestMixedInteger(unittest.TestCase):
         self.assertEqual(np.shape(y), (105, 1))
 
     def test_mixed_homo_hyp_2D(self):
-        import matplotlib.pyplot as plt
-        import numpy as np
-        import itertools
-
-        from smt.surrogate_models import KRG, ENUM, FLOAT, HOMO_HSPHERE_KERNEL
-        from smt.applications.mixed_integer import MixedIntegerKrigingModel
-
         xt = np.array([[0, 5], [2, -1], [4, 0.5]])
         yt = np.array([[0.0], [1.0], [1.5]])
         xlimits = [["0.0", "1.0", " 2.0", "3.0", "4.0"], [-5, 5]]
@@ -510,13 +508,6 @@ class TestMixedInteger(unittest.TestCase):
         self.assertEqual(np.shape(y), (105, 1))
 
     def test_mixed_homo_gaussian_3D_PLS(self):
-        import matplotlib.pyplot as plt
-        import numpy as np
-        import itertools
-
-        from smt.surrogate_models import KPLS, ENUM, FLOAT, EXP_HOMO_HSPHERE_KERNEL
-        from smt.applications.mixed_integer import MixedIntegerKrigingModel
-
         xt = np.array([[0.5, 0, 5], [2, 3, 4], [5, 2, -1], [-2, 4, 0.5]])
         yt = np.array([[0.0], [3], [1.0], [1.5]])
         xlimits = [[-5, 5], ["0.0", "1.0", " 2.0", "3.0", "4.0"], [-5, 5]]
@@ -551,12 +542,6 @@ class TestMixedInteger(unittest.TestCase):
         self.assertTrue((np.abs(np.sum(np.array(sm.predict_variances(xt) - 0)))) < 1e-6)
 
     def test_mixed_homo_gaussian_3D_PLS_cate(self):
-        import matplotlib.pyplot as plt
-        import numpy as np
-        import itertools
-
-        from smt.surrogate_models import KPLS, ENUM, FLOAT, EXP_HOMO_HSPHERE_KERNEL
-
         xt = np.array([[0.5, 0, 5], [2, 3, 4], [5, 2, -1], [-2, 4, 0.5]])
         yt = np.array([[0.0], [3], [1.0], [1.5]])
         xlimits = [[-5, 5], ["0.0", "1.0", " 2.0", "3.0", "4.0"], [-5, 5]]
@@ -592,13 +577,6 @@ class TestMixedInteger(unittest.TestCase):
         self.assertTrue((np.abs(np.sum(np.array(sm.predict_variances(xt) - 0)))) < 1e-6)
 
     def test_mixed_homo_hyp_3D_PLS_cate(self):
-        import matplotlib.pyplot as plt
-        import numpy as np
-        import itertools
-
-        from smt.surrogate_models import KPLS, ENUM, FLOAT, HOMO_HSPHERE_KERNEL
-        from smt.applications.mixed_integer import MixedIntegerKrigingModel
-
         xt = np.array([[0.5, 0, 5], [2, 3, 4], [5, 2, -1], [-2, 4, 0.5]])
         yt = np.array([[0.0], [3], [1.0], [1.5]])
         xlimits = [[-5, 5], ["0.0", "1.0", " 2.0", "3.0", "4.0"], [-5, 5]]
@@ -635,13 +613,6 @@ class TestMixedInteger(unittest.TestCase):
         self.assertTrue((np.abs(np.sum(np.array(sm.predict_variances(xt) - 0)))) < 1e-6)
 
     def test_mixed_homo_gaussian_3D_ord_cate(self):
-        import matplotlib.pyplot as plt
-        import numpy as np
-        import itertools
-
-        from smt.surrogate_models import KPLS, ORD, ENUM, EXP_HOMO_HSPHERE_KERNEL
-        from smt.applications.mixed_integer import MixedIntegerKrigingModel
-
         xt = np.array([[0.5, 0, 5], [2, 3, 4], [5, 2, -1], [-2, 4, 0.5]])
         yt = np.array([[0.0], [3], [1.0], [1.5]])
         xlimits = [
@@ -681,37 +652,38 @@ class TestMixedInteger(unittest.TestCase):
         self.assertTrue((np.abs(np.sum(np.array(sm.predict_values(xt) - yt)) < 1e-6)))
         self.assertTrue((np.abs(np.sum(np.array(sm.predict_variances(xt) - 0)) < 1e-6)))
 
-        def test_mixed_gower_3D(self):
-            from smt.problems import Sphere
-            from smt.sampling_methods import LHS
-            from smt.surrogate_models import KRG, FLOAT, ENUM, ORD, GOWER_KERNEL
+    def test_mixed_gower_3D(self):
+        xtypes = [FLOAT, ORD, ORD]
+        xlimits = [[-10, 10], [-10, 10], [-10, 10]]
+        xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
+        mixint = MixedIntegerContext(xspecs=xspecs)
 
-            xtypes = [FLOAT, ORD, ORD]
-            xlimits = [[-10, 10], [-10, 10], [-10, 10]]
-            xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
-            mixint = MixedIntegerContext(xspecs=xspecs)
+        sm = mixint.build_kriging_model(
+            KRG(categorical_kernel=GOWER_KERNEL, print_prediction=False)
+        )
+        sampling = mixint.build_sampling_method(LHS, criterion="m")
 
-            sm = mixint.build_kriging_model(
-                KRG(categorical_kernel=GOWER_KERNEL, print_prediction=False)
-            )
-            sampling = mixint.build_sampling_method(LHS, criterion="m")
+        fun = Sphere(ndim=3)
+        xt = sampling(10)
+        yt = fun(xt)
+        sm.set_training_values(xt, yt)
+        sm.train()
+        eq_check = True
+        for i in range(xt.shape[0]):
+            if abs(float(xt[i, :][1]) - int(float(xt[i, :][1]))) > 10e-8:
+                eq_check = False
+        self.assertTrue(eq_check)
 
-            fun = Sphere(ndim=3)
-            xt = sampling(10)
-            yt = fun(xt)
-            sm.set_training_values(xt, yt)
-            sm.train()
-            eq_check = True
-            for i in range(xt.shape[0]):
-                if abs(float(xt[i, :][1]) - int(float(xt[i, :][1]))) > 10e-8:
-                    eq_check = False
-            self.assertTrue(eq_check)
+    def test_examples(self):
+        self.run_mixed_gower_example()
+        self.run_mixed_homo_gaussian_example()
+        self.run_mixed_homo_hyp_example()
 
-    def test_mixed_gower(self):
+    def run_mixed_gower_example(self):
         import numpy as np
         import matplotlib.pyplot as plt
 
-        from smt.surrogate_models import KRG, ENUM, FLOAT, GOWER_KERNEL
+        from smt.surrogate_models import KRG, ENUM, FLOAT, XSpecs, GOWER_KERNEL
         from smt.applications.mixed_integer import MixedIntegerKrigingModel
 
         xt1 = np.array([[0, 0.0], [0, 2.0], [0, 4.0]])
@@ -826,7 +798,7 @@ class TestMixedInteger(unittest.TestCase):
         plt.tight_layout()
         plt.show()
 
-    def test_mixed_homo_gaussian(self):
+    def run_mixed_homo_gaussian_example(self):
         import numpy as np
         import matplotlib.pyplot as plt
 
@@ -834,6 +806,7 @@ class TestMixedInteger(unittest.TestCase):
             KRG,
             ENUM,
             FLOAT,
+            XSpecs,
             EXP_HOMO_HSPHERE_KERNEL,
         )
         from smt.applications.mixed_integer import MixedIntegerKrigingModel
@@ -950,11 +923,11 @@ class TestMixedInteger(unittest.TestCase):
         plt.tight_layout()
         plt.show()
 
-    def test_mixed_homo_hyp(self):
+    def run_mixed_homo_hyp_example(self):
         import numpy as np
         import matplotlib.pyplot as plt
 
-        from smt.surrogate_models import KRG, HOMO_HSPHERE_KERNEL, ENUM, FLOAT
+        from smt.surrogate_models import KRG, ENUM, FLOAT, XSpecs, HOMO_HSPHERE_KERNEL
         from smt.applications.mixed_integer import MixedIntegerKrigingModel
 
         xt1 = np.array([[0, 0.0], [0, 2.0], [0, 4.0]])

--- a/smt/applications/tests/test_mixed_integer.py
+++ b/smt/applications/tests/test_mixed_integer.py
@@ -29,14 +29,12 @@ class TestMixedInteger(unittest.TestCase):
     def test_krg_mixed_3D_INT(self):
         xtypes = [FLOAT, (ENUM, 3), ORD]
         xlimits = [[-10, 10], ["blue", "red", "green"], [-10, 10]]
-        xspecs = XSpecs()
-        xspecs["xtypes"] = xtypes
-        xspecs["xlimits"] = xlimits
+        xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
 
-        mixint = MixedIntegerContext()
+        mixint = MixedIntegerContext(xspecs=xspecs)
 
-        sm = mixint.build_kriging_model(KRG(xspecs=xspecs, print_prediction=False))
-        sampling = mixint.build_sampling_method(LHS, xspecs, criterion="m")
+        sm = mixint.build_kriging_model(KRG(print_prediction=False))
+        sampling = mixint.build_sampling_method(LHS, criterion="m")
 
         fun = Sphere(ndim=3)
         xt = sampling(20)
@@ -55,15 +53,12 @@ class TestMixedInteger(unittest.TestCase):
     def test_krg_mixed_3D(self):
         xtypes = [FLOAT, (ENUM, 3), ORD]
         xlimits = [[-10, 10], ["blue", "red", "green"], [-10, 10]]
-        xspecs = XSpecs()
+        xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
 
-        xspecs["xtypes"] = xtypes
-        xspecs["xlimits"] = xlimits
+        mixint = MixedIntegerContext(xspecs=xspecs)
 
-        mixint = MixedIntegerContext()
-
-        sm = mixint.build_kriging_model(KRG(xspecs=xspecs, print_prediction=False))
-        sampling = mixint.build_sampling_method(LHS, xspecs, criterion="m")
+        sm = mixint.build_kriging_model(KRG(print_prediction=False))
+        sampling = mixint.build_sampling_method(LHS, criterion="m")
 
         fun = Sphere(ndim=3)
         xt = sampling(20)
@@ -82,26 +77,18 @@ class TestMixedInteger(unittest.TestCase):
     def test_krg_mixed_3D_bad_regr(self):
         xtypes = [FLOAT, (ENUM, 3), ORD]
         xlimits = [[-10, 10], ["blue", "red", "green"], [-10, 10]]
-        xspecs = XSpecs()
+        xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
 
-        xspecs["xtypes"] = xtypes
-        xspecs["xlimits"] = xlimits
-
-        mixint = MixedIntegerContext()
+        mixint = MixedIntegerContext(xspecs=xspecs)
         with self.assertRaises(ValueError):
-            sm = mixint.build_kriging_model(
-                KRG(xspecs=xspecs, print_prediction=False, poly="linear")
-            )
+            sm = mixint.build_kriging_model(KRG(print_prediction=False, poly="linear"))
 
     def test_qp_mixed_2D_INT(self):
         xtypes = [FLOAT, ORD]
         xlimits = [[-10, 10], [-10, 10]]
-        xspecs = XSpecs()
+        xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
 
-        xspecs["xtypes"] = xtypes
-        xspecs["xlimits"] = xlimits
-
-        mixint = MixedIntegerContext(xspecs)
+        mixint = MixedIntegerContext(xspecs=xspecs)
         sm = mixint.build_surrogate_model(QP(print_prediction=False))
         sampling = mixint.build_sampling_method(LHS, criterion="m")
 
@@ -157,10 +144,7 @@ class TestMixedInteger(unittest.TestCase):
     def test_unfolded_xlimits_type(self):
         xtypes = [FLOAT, (ENUM, 2), (ENUM, 2), ORD]
         xlimits = np.array([[-5, 5], ["2", "3"], ["4", "5"], [0, 2]])
-        xspecs = XSpecs()
-
-        xspecs["xtypes"] = xtypes
-        xspecs["xlimits"] = xlimits
+        xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
         sampling = MixedIntegerSamplingMethod(LHS, xspecs, criterion="ese")
         doe = sampling(10)
         self.assertEqual((10, 4), doe.shape)
@@ -171,10 +155,7 @@ class TestMixedInteger(unittest.TestCase):
             [[-5, 5], ["blue", "red"], ["short", "medium", "long"], [0, 2]],
             dtype="object",
         )
-        xspecs = XSpecs()
-
-        xspecs["xtypes"] = xtypes
-        xspecs["xlimits"] = xlimits
+        xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
 
         x = np.array([1.5, 0, 2, 1.1])
         self.assertEqual([1.5, "blue", "long", 1], cast_to_mixed_integer(xspecs, x))
@@ -185,10 +166,7 @@ class TestMixedInteger(unittest.TestCase):
             [[-5, 5], ["blue", "red"], ["short", "medium", "long"], [0, 2]],
             dtype="object",
         )
-        xspecs = XSpecs()
-
-        xspecs["xtypes"] = xtypes
-        xspecs["xlimits"] = xlimits
+        xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
 
         x = [1.5, "blue", "long", 1]
         self.assertEqual(
@@ -205,10 +183,7 @@ class TestMixedInteger(unittest.TestCase):
             [[-5, 5], ["blue", "red"], ["short", "medium", "long"], [0, 2]],
             dtype="object",
         )
-        xspecs = XSpecs()
-
-        xspecs["xtypes"] = xtypes
-        xspecs["xlimits"] = xlimits
+        xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
 
         l = unfold_xlimits_with_continuous_limits(xspecs)
         self.assertEqual(
@@ -225,10 +200,7 @@ class TestMixedInteger(unittest.TestCase):
             [[-5, 5], ["blue", "red"], ["short", "medium", "long"], ["0", "3", "4"]],
             dtype="object",
         )
-        xspecs = XSpecs()
-
-        xspecs["xtypes"] = xtypes
-        xspecs["xlimits"] = xlimits
+        xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
 
         l = unfold_xlimits_with_continuous_limits(xspecs)
 
@@ -246,10 +218,7 @@ class TestMixedInteger(unittest.TestCase):
             [[-5, 5], ["blue", "red"], ["short", "medium", "long"], [0, 4]],
             dtype="object",
         )
-        xspecs = XSpecs()
-
-        xspecs["xtypes"] = xtypes
-        xspecs["xlimits"] = xlimits
+        xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
 
         x = np.array([[2.6, 0.3, 0.5, 0.25, 0.45, 0.85, 3.1]])
 
@@ -269,10 +238,7 @@ class TestMixedInteger(unittest.TestCase):
             [[-5, 5], ["blue", "red"], ["short", "medium", "long"], ["0", "2", "4"]],
             dtype="object",
         )
-        xspecs = XSpecs()
-
-        xspecs["xtypes"] = xtypes
-        xspecs["xlimits"] = xlimits
+        xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
 
         self.assertEqual(
             np.array_equal(
@@ -290,10 +256,7 @@ class TestMixedInteger(unittest.TestCase):
             [[-5, 5], ["blue", "red"], ["short", "medium", "long"], ["0", "4"]],
             dtype="object",
         )
-        xspecs = XSpecs()
-
-        xspecs["xtypes"] = xtypes
-        xspecs["xlimits"] = xlimits
+        xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
 
         self.assertEqual(
             np.array_equal(
@@ -311,10 +274,7 @@ class TestMixedInteger(unittest.TestCase):
             [[-5, 5], ["blue", "red"], ["short", "medium", "long"], ["0", "3.5"]],
             dtype="object",
         )
-        xspecs = XSpecs()
-
-        xspecs["xtypes"] = xtypes
-        xspecs["xlimits"] = xlimits
+        xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
 
         self.assertEqual(
             np.array_equal(
@@ -334,10 +294,7 @@ class TestMixedInteger(unittest.TestCase):
 
         xtypes = [FLOAT, (ENUM, 2)]
         xlimits = [[0.0, 4.0], ["blue", "red"]]
-        xspecs = XSpecs()
-
-        xspecs["xtypes"] = xtypes
-        xspecs["xlimits"] = xlimits
+        xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
 
         sampling = MixedIntegerSamplingMethod(LHS, xspecs, criterion="ese")
 
@@ -363,10 +320,8 @@ class TestMixedInteger(unittest.TestCase):
         # ORD means x2 ordered
         # (ENUM, 3) means x3, x4 & x5 are 3 levels of the same categorical variable
         # (ENUM, 2) means x6 & x7 are 2 levels of the same categorical variable
-
-        sm = MixedIntegerSurrogateModel(
-            xspec={"xtypes": [ORD], "xlimits": [[0, 4]]}, surrogate=QP()
-        )
+        xspecs = XSpecs(xtypes=[ORD], xlimits=[[0, 4]])
+        sm = MixedIntegerSurrogateModel(xspecs=xspecs, surrogate=QP())
         sm.set_training_values(xt, yt)
         sm.train()
 
@@ -393,16 +348,13 @@ class TestMixedInteger(unittest.TestCase):
 
         xtypes = [ORD, FLOAT, (ENUM, 4)]
         xlimits = [[0, 5], [0.0, 4.0], ["blue", "red", "green", "yellow"]]
-        xspecs = XSpecs()
-
-        xspecs["xtypes"] = xtypes
-        xspecs["xlimits"] = xlimits
+        xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
 
         def ftest(x):
             return (x[:, 0] * x[:, 0] + x[:, 1] * x[:, 1]) * (x[:, 2] + 1)
 
         # context to create consistent DOEs and surrogate
-        mixint = MixedIntegerContext(xspecs)
+        mixint = MixedIntegerContext(xspecs=xspecs)
 
         # DOE for training
         lhs = mixint.build_sampling_method(LHS, criterion="ese")
@@ -442,15 +394,16 @@ class TestMixedInteger(unittest.TestCase):
         yt = np.array([[0.0], [1.0], [1.5]])
         xlimits = [["0.0", "1.0", " 2.0", "3.0", "4.0"], [-5, 5]]
         xtypes = [(ENUM, 5), FLOAT]
-        xspecs = XSpecs()
-
-        xspecs["xtypes"] = xtypes
-        xspecs["xlimits"] = xlimits
+        xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
 
         # Surrogate
         sm = MixedIntegerKrigingModel(
-            categorical_kernel=GOWER_KERNEL,
-            surrogate=KRG(xspecs=xspecs, theta0=[1e-2], corr="abs_exp"),
+            surrogate=KRG(
+                xspecs=xspecs,
+                theta0=[1e-2],
+                corr="abs_exp",
+                categorical_kernel=GOWER_KERNEL,
+            ),
         )
         sm.set_training_values(xt, yt)
         sm.train()
@@ -484,14 +437,15 @@ class TestMixedInteger(unittest.TestCase):
         yt = np.array([[0.0], [1.0], [1.5]])
         xlimits = [["0.0", "1.0", " 2.0", "3.0", "4.0"], [-5, 5]]
         xtypes = [(ENUM, 5), FLOAT]
-        xspecs = XSpecs()
-
-        xspecs["xtypes"] = xtypes
-        xspecs["xlimits"] = xlimits
+        xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
         # Surrogate
         sm = MixedIntegerKrigingModel(
-            categorical_kernel=EXP_HOMO_HSPHERE_KERNEL,
-            surrogate=KRG(xspecs=xspecs, theta0=[1e-2], corr="abs_exp"),
+            surrogate=KRG(
+                xspecs=xspecs,
+                theta0=[1e-2],
+                corr="abs_exp",
+                categorical_kernel=EXP_HOMO_HSPHERE_KERNEL,
+            ),
         )
         sm.set_training_values(xt, yt)
         sm.train()
@@ -525,14 +479,15 @@ class TestMixedInteger(unittest.TestCase):
         yt = np.array([[0.0], [1.0], [1.5]])
         xlimits = [["0.0", "1.0", " 2.0", "3.0", "4.0"], [-5, 5]]
         xtypes = [(ENUM, 5), FLOAT]
-        xspecs = XSpecs()
-
-        xspecs["xtypes"] = xtypes
-        xspecs["xlimits"] = xlimits
+        xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
         # Surrogate
         sm = MixedIntegerKrigingModel(
-            categorical_kernel=HOMO_HSPHERE_KERNEL,
-            surrogate=KRG(xspecs=xspecs, theta0=[1e-2], corr="abs_exp"),
+            surrogate=KRG(
+                xspecs=xspecs,
+                theta0=[1e-2],
+                categorical_kernel=HOMO_HSPHERE_KERNEL,
+                corr="abs_exp",
+            ),
         )
         sm.set_training_values(xt, yt)
         sm.train()
@@ -566,20 +521,15 @@ class TestMixedInteger(unittest.TestCase):
         yt = np.array([[0.0], [3], [1.0], [1.5]])
         xlimits = [[-5, 5], ["0.0", "1.0", " 2.0", "3.0", "4.0"], [-5, 5]]
         xtypes = [FLOAT, (ENUM, 5), FLOAT]
-        xspecs = XSpecs()
-
-        xspecs["xtypes"] = xtypes
-        xspecs["xlimits"] = xlimits
+        xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
         # Surrogate
-        sm = MixedIntegerKrigingModel(
+        sm = surrogate = KPLS(
+            xspecs=xspecs,
+            theta0=[1e-2],
+            n_comp=1,
             categorical_kernel=EXP_HOMO_HSPHERE_KERNEL,
-            surrogate=KPLS(
-                xspecs=xspecs,
-                theta0=[1e-2],
-                n_comp=1,
-                cat_kernel_comps=[3],
-                corr="squar_exp",
-            ),
+            cat_kernel_comps=[3],
+            corr="squar_exp",
         )
         sm.set_training_values(xt, yt)
         sm.train()
@@ -606,27 +556,22 @@ class TestMixedInteger(unittest.TestCase):
         import itertools
 
         from smt.surrogate_models import KPLS, ENUM, FLOAT, EXP_HOMO_HSPHERE_KERNEL
-        from smt.applications.mixed_integer import MixedIntegerKrigingModel
 
         xt = np.array([[0.5, 0, 5], [2, 3, 4], [5, 2, -1], [-2, 4, 0.5]])
         yt = np.array([[0.0], [3], [1.0], [1.5]])
         xlimits = [[-5, 5], ["0.0", "1.0", " 2.0", "3.0", "4.0"], [-5, 5]]
         xtypes = [FLOAT, (ENUM, 5), FLOAT]
-        xspecs = XSpecs()
-
-        xspecs["xtypes"] = xtypes
-        xspecs["xlimits"] = xlimits
+        xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
         # Surrogate
-        sm = MixedIntegerKrigingModel(
+        sm = KPLS(
+            xspecs=xspecs,
+            theta0=[1e-2],
+            n_comp=2,
+            corr="abs_exp",
+            cat_kernel_comps=[3],
             categorical_kernel=EXP_HOMO_HSPHERE_KERNEL,
-            surrogate=KPLS(
-                xspecs=xspecs,
-                theta0=[1e-2],
-                n_comp=2,
-                cat_kernel_comps=[3],
-                corr="abs_exp",
-            ),
         )
+
         sm.set_training_values(xt, yt)
         sm.train()
 
@@ -658,17 +603,14 @@ class TestMixedInteger(unittest.TestCase):
         yt = np.array([[0.0], [3], [1.0], [1.5]])
         xlimits = [[-5, 5], ["0.0", "1.0", " 2.0", "3.0", "4.0"], [-5, 5]]
         xtypes = [FLOAT, (ENUM, 5), FLOAT]
-        xspecs = XSpecs()
-
-        xspecs["xtypes"] = xtypes
-        xspecs["xlimits"] = xlimits
+        xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
         # Surrogate
         sm = MixedIntegerKrigingModel(
-            categorical_kernel=HOMO_HSPHERE_KERNEL,
             surrogate=KPLS(
                 xspecs=xspecs,
                 theta0=[1e-2],
                 n_comp=1,
+                categorical_kernel=HOMO_HSPHERE_KERNEL,
                 cat_kernel_comps=[3],
                 corr="squar_exp",
             ),
@@ -708,17 +650,14 @@ class TestMixedInteger(unittest.TestCase):
             ["0.0", "1.0", " 2.0", "3.0"],
         ]
         xtypes = [(ENUM, 5), ORD, (ENUM, 4)]
-        xspecs = XSpecs()
-
-        xspecs["xtypes"] = xtypes
-        xspecs["xlimits"] = xlimits
+        xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
         # Surrogate
         sm = MixedIntegerKrigingModel(
-            categorical_kernel=EXP_HOMO_HSPHERE_KERNEL,
             surrogate=KPLS(
                 xspecs=xspecs,
                 theta0=[1e-2],
                 n_comp=1,
+                categorical_kernel=EXP_HOMO_HSPHERE_KERNEL,
                 cat_kernel_comps=[3, 2],
                 corr="squar_exp",
             ),
@@ -749,13 +688,12 @@ class TestMixedInteger(unittest.TestCase):
 
             xtypes = [FLOAT, ORD, ORD]
             xlimits = [[-10, 10], [-10, 10], [-10, 10]]
-            xspecs = XSpecs()
+            xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
+            mixint = MixedIntegerContext(xspecs=xspecs)
 
-            xspecs["xtypes"] = xtypes
-            xspecs["xlimits"] = xlimits
-            mixint = MixedIntegerContext(xspecs, categorical_kernel=GOWER_KERNEL)
-
-            sm = mixint.build_kriging_model(KRG(print_prediction=False))
+            sm = mixint.build_kriging_model(
+                KRG(categorical_kernel=GOWER_KERNEL, print_prediction=False)
+            )
             sampling = mixint.build_sampling_method(LHS, criterion="m")
 
             fun = Sphere(ndim=3)
@@ -789,14 +727,16 @@ class TestMixedInteger(unittest.TestCase):
         yt = np.concatenate((yt1, yt2, yt3), axis=0)
         xlimits = [["Blue", "Red", "Green"], [0.0, 4.0]]
         xtypes = [(ENUM, 3), FLOAT]
-        xspecs = XSpecs()
-
-        xspecs["xtypes"] = xtypes
-        xspecs["xlimits"] = xlimits
+        xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
         # Surrogate
         sm = MixedIntegerKrigingModel(
-            categorical_kernel=GOWER_KERNEL,
-            surrogate=KRG(xspecs=xspecs, theta0=[1e-1], corr="squar_exp", n_start=20),
+            surrogate=KRG(
+                xspecs=xspecs,
+                categorical_kernel=GOWER_KERNEL,
+                theta0=[1e-1],
+                corr="squar_exp",
+                n_start=20,
+            ),
         )
         sm.set_training_values(xt, yt)
         sm.train()
@@ -911,14 +851,16 @@ class TestMixedInteger(unittest.TestCase):
         yt = np.concatenate((yt1, yt2, yt3), axis=0)
         xlimits = [["Blue", "Red", "Green"], [0.0, 4.0]]
         xtypes = [(ENUM, 3), FLOAT]
-        xspecs = XSpecs()
-
-        xspecs["xtypes"] = xtypes
-        xspecs["xlimits"] = xlimits
+        xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
         # Surrogate
         sm = MixedIntegerKrigingModel(
-            categorical_kernel=EXP_HOMO_HSPHERE_KERNEL,
-            surrogate=KRG(xspecs=xspecs, theta0=[1e-1], corr="squar_exp", n_start=20),
+            surrogate=KRG(
+                xspecs=xspecs,
+                theta0=[1e-1],
+                corr="squar_exp",
+                n_start=20,
+                categorical_kernel=EXP_HOMO_HSPHERE_KERNEL,
+            ),
         )
         sm.set_training_values(xt, yt)
         sm.train()
@@ -1028,14 +970,16 @@ class TestMixedInteger(unittest.TestCase):
         yt = np.concatenate((yt1, yt2, yt3), axis=0)
         xlimits = [["Blue", "Red", "Green"], [0.0, 4.0]]
         xtypes = [(ENUM, 3), FLOAT]
-        xspecs = XSpecs()
-
-        xspecs["xtypes"] = xtypes
-        xspecs["xlimits"] = xlimits
+        xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
         # Surrogate
         sm = MixedIntegerKrigingModel(
-            categorical_kernel=HOMO_HSPHERE_KERNEL,
-            surrogate=KRG(xspecs=xspecs, theta0=[1e-1], corr="squar_exp", n_start=20),
+            surrogate=KRG(
+                xspecs=xspecs,
+                categorical_kernel=HOMO_HSPHERE_KERNEL,
+                theta0=[1e-1],
+                corr="squar_exp",
+                n_start=20,
+            ),
         )
         sm.set_training_values(xt, yt)
         sm.train()

--- a/smt/examples/run_examples.py
+++ b/smt/examples/run_examples.py
@@ -11,7 +11,7 @@ from smt.utils import compute_rms_error
 
 from smt.problems import Sphere, NdimRobotArm
 from smt.sampling_methods import LHS
-from smt.surrogate_models import LS, QP, KPLS, KRG, KPLSK, GEKPLS
+from smt.surrogate_models import LS, QP, KPLS, KRG, KPLSK, GEKPLS, XSpecs
 
 try:
     from smt.surrogate_models import IDW, RBF, RMTC, RMTB
@@ -342,11 +342,11 @@ if plot_status:
 ########### The GEKPLS model using 1 approximating points
 
 # 'n_comp' and 'theta0' must be an integer in [1,ndim[ and a list of length n_comp, respectively.
-
+xspecs = XSpecs(xlimits=fun.xlimits)
 t = GEKPLS(
     n_comp=1,
     theta0=[1e-2],
-    xlimits=fun.xlimits,
+    xspecs=xspecs,
     delta_x=1e-2,
     extra_points=1,
     print_prediction=False,

--- a/smt/surrogate_models/__init__.py
+++ b/smt/surrogate_models/__init__.py
@@ -14,6 +14,7 @@ from .krg_based import (
     EXP_HOMO_HSPHERE_KERNEL,
 )
 from smt.utils.mixed_integer import FLOAT, INT, ORD, ENUM
+from smt.utils.kriging_utils import XSpecs
 
 try:
     from .idw import IDW

--- a/smt/surrogate_models/gekpls.py
+++ b/smt/surrogate_models/gekpls.py
@@ -50,7 +50,7 @@ class GEKPLS(KPLS):
                 self.options["n_comp"],
                 self.training_points,
                 self.options["delta_x"],
-                self.options["xspecs"]["xlimits"],
+                self.options["xspecs"].limits,
                 self.options["extra_points"],
             )
             if self.options["extra_points"] != 0:

--- a/smt/surrogate_models/tests/test_surrogate_model_examples.py
+++ b/smt/surrogate_models/tests/test_surrogate_model_examples.py
@@ -240,10 +240,7 @@ class Test(unittest.TestCase):
         # ORD means x2 integer
         # (ENUM, 3) means x3, x4 & x5 are 3 levels of the same categorical variable
         # (ENUM, 2) means x6 & x7 are 2 levels of the same categorical variable
-        xspecs = XSpecs()
-        xspecs["xtypes"] = [ORD]
-        xspecs["xlimits"] = [[0, 4]]
-
+        xspecs = XSpecs(xtypes=[ORD], xlimits=[[0, 4]])
         sm = MixedIntegerKrigingModel(surrogate=KRG(xspecs=xspecs, theta0=[1e-2]))
         sm.set_training_values(xt, yt)
         sm.train()
@@ -283,13 +280,15 @@ class Test(unittest.TestCase):
 
         xt = np.array([0, 3, 4])
         yt = np.array([0.0, 1.0, 1.5])
-        xspecs = XSpecs()
-        xspecs["xtypes"] = [(ENUM, 5)]
-        xspecs["xlimits"] = [["0.0", "1.0", " 2.0", "3.0", "4.0"]]
+        xspecs = XSpecs(
+            xtypes=[(ENUM, 5)], xlimits=[["0.0", "1.0", " 2.0", "3.0", "4.0"]]
+        )
+
         # Surrogate
         sm = MixedIntegerKrigingModel(
-            categorical_kernel=GOWER_KERNEL,
-            surrogate=KRG(xspecs=xspecs, theta0=[1e-2]),
+            surrogate=KRG(
+                xspecs=xspecs, theta0=[1e-2], categorical_kernel=GOWER_KERNEL
+            ),
         )
         sm.set_training_values(xt, yt)
         sm.train()
@@ -436,8 +435,7 @@ class Test(unittest.TestCase):
         for i in range(2):
             yd = fun(xt, kx=i)
             yt = np.concatenate((yt, yd), axis=1)
-        xspecs = XSpecs()
-        xspecs["xlimits"] = fun.xlimits
+        xspecs = XSpecs(xlimits=fun.xlimits)
         # Build the GEKPLS model
         n_comp = 2
         sm = GEKPLS(

--- a/smt/tests/test_all.py
+++ b/smt/tests/test_all.py
@@ -145,9 +145,7 @@ class Test(SMTestCase):
         sm = sm0.__class__()
         sm.options = sm0.options.clone()
         if sm.options.is_declared("xspecs"):
-            sm.options["xspecs"] = XSpecs()
-            sm.options["xspecs"]["xlimits"] = prob.xlimits
-            {"xlimits": prob.xlimits}
+            sm.options["xspecs"] = XSpecs(xlimits=prob.xlimits)
         if sm.options.is_declared("xlimits"):
             sm.options["xlimits"] = prob.xlimits
         sm.options["print_global"] = False

--- a/smt/tests/test_derivs.py
+++ b/smt/tests/test_derivs.py
@@ -79,8 +79,7 @@ class Test(SMTestCase):
         sm = sm0.__class__()
         sm.options = sm0.options.clone()
         if sm.options.is_declared("xspecs"):
-            sm.options["xspecs"] = XSpecs()
-            sm.options["xspecs"]["xlimits"] = prob.xlimits
+            sm.options["xspecs"] = XSpecs(xlimits=prob.xlimits)
         if sm.options.is_declared("xlimits"):
             sm.options["xlimits"] = prob.xlimits
         sm.options["print_global"] = False

--- a/smt/tests/test_extrap.py
+++ b/smt/tests/test_extrap.py
@@ -60,8 +60,7 @@ class Test(SMTestCase):
         sm = sm0.__class__()
         sm.options = sm0.options.clone()
         if sm.options.is_declared("xspecs"):
-            sm.options["xspecs"] = XSpecs()
-            sm.options["xspecs"]["xlimits"] = prob.xlimits
+            sm.options["xspecs"] = XSpecs(xlimits=prob.xlimits)
         if sm.options.is_declared("xlimits"):
             sm.options["xlimits"] = prob.xlimits
         sm.options["print_global"] = False

--- a/smt/tests/test_low_dim.py
+++ b/smt/tests/test_low_dim.py
@@ -89,8 +89,7 @@ class Test(SMTestCase):
         sm = sm0.__class__()
         sm.options = sm0.options.clone()
         if sm.options.is_declared("xspecs"):
-            sm.options["xspecs"] = XSpecs()
-            sm.options["xspecs"]["xlimits"] = prob.xlimits
+            sm.options["xspecs"] = XSpecs(xlimits=prob.xlimits)
         if sm.options.is_declared("xlimits"):
             sm.options["xlimits"] = prob.xlimits
         sm.options["print_global"] = False

--- a/smt/tests/test_output_derivs.py
+++ b/smt/tests/test_output_derivs.py
@@ -74,8 +74,7 @@ class Test(SMTestCase):
         sm = sm0.__class__()
         sm.options = sm0.options.clone()
         if sm.options.is_declared("xspecs"):
-            sm.options["xspecs"] = XSpecs()
-            sm.options["xspecs"]["xlimits"] = prob.xlimits
+            sm.options["xspecs"] = XSpecs(xlimits=prob.xlimits)
         if sm.options.is_declared("xlimits"):
             sm.options["xlimits"] = prob.xlimits
         sm.options["print_global"] = False

--- a/smt/tests/test_training_derivs.py
+++ b/smt/tests/test_training_derivs.py
@@ -114,8 +114,7 @@ class Test(SMTestCase):
         sm = sm0.__class__()
         sm.options = sm0.options.clone()
         if sm.options.is_declared("xspecs"):
-            sm.options["xspecs"] = XSpecs()
-            sm.options["xspecs"]["xlimits"] = prob.xlimits
+            sm.options["xspecs"] = XSpecs(xlimits=prob.xlimits)
         if sm.options.is_declared("xlimits"):
             sm.options["xlimits"] = prob.xlimits
         sm.options["print_global"] = False

--- a/smt/utils/mixed_integer.py
+++ b/smt/utils/mixed_integer.py
@@ -56,8 +56,8 @@ def unfold_xlimits_with_continuous_limits(xspecs, unfold_space=True):
         bounds of the each dimension where limits for enumerates (ENUM)
         are expanded ([0, 1] for each level).
     """
-    xtypes = xspecs["xtypes"]
-    xlimits = xspecs["xlimits"]
+    xtypes = xspecs.types
+    xlimits = xspecs.limits
     # Continuous optimization : do nothing
     xlims = []
     for i, xtyp in enumerate(xtypes):
@@ -79,10 +79,8 @@ def unfold_xlimits_with_continuous_limits(xspecs, unfold_space=True):
                     xlims.append(listint)
             else:
                 raise ValueError(
-                    "Bad xlimits for categorical var[{}] "
-                    "should have {} categories, got only {} in {}".format(
-                        i, xtyp[1], len(xlimits[i]), xlimits[i]
-                    )
+                    f"Bad xlimits for categorical var[{i}] "
+                    f"should have {xtyp[1]} categories, got only {len(xlimits[i])} in {xlimits[i]}"
                 )
         else:
             _raise_value_error(xtyp)
@@ -93,8 +91,8 @@ def cast_to_discrete_values(xspecs, unfold_space, x):
     """
     see MixedIntegerContext.cast_to_discrete_values
     """
-    xtypes = xspecs["xtypes"]
-    xlimits = xspecs["xlimits"]
+    xtypes = xspecs.types
+    xlimits = xspecs.limits
     ret = ensure_2d_array(x, "x").copy()
     x_col = 0
     for i, xtyp in enumerate(xtypes):
@@ -180,9 +178,8 @@ def cast_to_mixed_integer(xspecs, x):
     """
     see MixedIntegerContext.cast_to_mixed_integer
     """
-    xspecs.check_xspec_consistency()
-    xlimits = xspecs["xlimits"]
-    xtypes = xspecs["xtypes"]
+    xlimits = xspecs.limits
+    xtypes = xspecs.types
     res = []
     for i, xtyp in enumerate(xtypes):
         xi = x[i]
@@ -201,8 +198,8 @@ def encode_with_enum_index(xspecs, x):
     """
     see MixedIntegerContext.encode_with_enum_index
     """
-    xtypes = xspecs["xtypes"]
-    xlimits = xspecs["xlimits"]
+    xtypes = xspecs.types
+    xlimits = xspecs.limits
     res = []
     for i, xtyp in enumerate(xtypes):
         xi = x[i]

--- a/smt/utils/test/test_kriging_utils.py
+++ b/smt/utils/test/test_kriging_utils.py
@@ -16,53 +16,36 @@ from smt.utils.mixed_integer import (
 
 class Test(unittest.TestCase):
     def test_x_specs(self):
-        inst = XSpecs()
-        inst["xtypes"] = [3]
-        self.assertEqual(None, inst["xlimits"])
-        self.assertEqual([3], inst["xtypes"])
-        eq_check = False
-        try:
-            inst["a"] = [3]
-        except AssertionError:
-            eq_check = True
-        self.assertEqual(True, eq_check)
-        newdic = {"xlimits": [4], "xtypes": None}
-        inst.update(newdic)
-        inst2 = inst.clone()
-        self.assertEqual([4], inst2["xlimits"])
+        # xlimits has to be specified
+        with self.assertRaises(ValueError):
+            XSpecs(xtypes=[3])
 
-    def test_check_xspec_consistency(self):
+        # check consistency: badly-formed xlimits
+        with self.assertRaises(ValueError):
+            XSpecs(xlimits=[3])
+
+        # ok default to float
+        xspecs = XSpecs(xlimits=[[0, 1]])
+        self.assertEqual([FLOAT], xspecs.types)
+
+    def test_xspecs_check_consistency(self):
         xtypes = [FLOAT, (ENUM, 3), ORD]
         xlimits = [[-10, 10], ["blue", "red", "green"]]  # Bad dimension
-        xspecs = XSpecs()
-
-        xspecs["xtypes"] = xtypes
-        xspecs["xlimits"] = xlimits
-
         with self.assertRaises(ValueError):
-            xspecs.check_xspec_consistency()
+            XSpecs(xtypes=xtypes, xlimits=xlimits)
 
         xtypes = [FLOAT, (ENUM, 3), ORD]
         xlimits = [[-10, 10], ["blue", "red"], [-10, 10]]  # Bad enum
-        xspecs = XSpecs()
-
-        xspecs["xtypes"] = xtypes
-        xspecs["xlimits"] = xlimits
         with self.assertRaises(ValueError):
-            xspecs.check_xspec_consistency()
+            XSpecs(xtypes=xtypes, xlimits=xlimits)
 
         xtypes = [FLOAT, (ENUM, 2), (ENUM, 3), ORD]
         xlimits = np.array(
             [[-5, 5], ["blue", "red"], ["short", "medium", "long"], ["0", "4", "3"]],
             dtype="object",
         )
-        xspecs = XSpecs()
-
-        xspecs["xtypes"] = xtypes
-        xspecs["xlimits"] = xlimits
-        l = unfold_xlimits_with_continuous_limits(xspecs)
         with self.assertRaises(ValueError):
-            xspecs.check_xspec_consistency()
+            XSpecs(xtypes=xtypes, xlimits=xlimits)
 
 
 if __name__ == "__main__":

--- a/smt/utils/test/test_kriging_utils.py
+++ b/smt/utils/test/test_kriging_utils.py
@@ -21,7 +21,7 @@ class Test(unittest.TestCase):
             XSpecs(xtypes=[3])
 
         # check consistency: badly-formed xlimits
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             XSpecs(xlimits=[3])
 
         # ok default to float


### PR DESCRIPTION
This PR refactors XSpecs to enforce consistency at construction time. 

It reworks the API of `MixedInteger` classes: `MixedIntegerSamplingMethod`, `MixedIntegerSurrogateModel`, `MixedIntegerKrigingModel` and `MixedIntegerContext`