### PR TITLE
Skip expensive tests

### DIFF
--- a/.github/workflows/tests_coverage.yml
+++ b/.github/workflows/tests_coverage.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Test with pytest and coverage
       run: |
         pip install coverage
-        coverage run --source=smt -m pytest
+        RUN_SLOW=1 coverage run --source=smt -m pytest
 
     - name: Coveralls
       uses: AndreMiras/coveralls-python-action@develop

--- a/smt/applications/tests/test_ego.py
+++ b/smt/applications/tests/test_ego.py
@@ -109,6 +109,7 @@ class TestEGO(SMTestCase):
         self.assertAlmostEqual(18.9, float(x_opt), delta=1)
         self.assertAlmostEqual(-15.1, float(y_opt), delta=1)
 
+    @unittest.skipIf(int(os.getenv("RUN_SLOW", 0)) < 1, "too slow")
     def test_rosenbrock_2D(self):
         n_iter = 50
         fun = Rosenbrock(ndim=2)

--- a/smt/applications/tests/test_ego.py
+++ b/smt/applications/tests/test_ego.py
@@ -208,6 +208,7 @@ class TestEGO(SMTestCase):
         )
         self.assertAlmostEqual(0.39, float(y_opt), delta=0.75)
 
+    @unittest.skipIf(int(os.getenv("RUN_SLOW", 0)) < 1, "too slow")
     def test_branin_2D_parallel(self):
         n_iter = 10
         fun = Branin(ndim=2)
@@ -278,6 +279,7 @@ class TestEGO(SMTestCase):
         )
         self.assertAlmostEqual(0.494, float(y_opt), delta=1)
 
+    @unittest.skipIf(int(os.getenv("RUN_SLOW", 0)) < 1, "too slow")
     def test_branin_2D_mixed(self):
         n_iter = 20
         fun = Branin(ndim=2)

--- a/smt/applications/tests/test_ego.py
+++ b/smt/applications/tests/test_ego.py
@@ -8,8 +8,7 @@ import warnings
 
 warnings.filterwarnings("ignore")
 
-import time
-import sys
+import os
 import unittest
 import numpy as np
 from sys import argv
@@ -154,6 +153,7 @@ class TestEGO(SMTestCase):
         self.assertTrue(np.allclose([[1, 1]], x_opt, atol=1))
         self.assertAlmostEqual(0.0, float(y_opt), delta=1)
 
+    @unittest.skipIf(int(os.getenv("RUN_SLOW", 0)) < 1, "too slow")
     def test_rosenbrock_2D_parallel(self):
         n_iter = 20
         n_parallel = 5
@@ -238,6 +238,7 @@ class TestEGO(SMTestCase):
         print("Branin=", x_opt)
         self.assertAlmostEqual(0.39, float(y_opt), delta=1)
 
+    @unittest.skipIf(int(os.getenv("RUN_SLOW", 0)) < 1, "too slow")
     def test_branin_2D_mixed_parallel(self):
         n_parallel = 5
         n_iter = 20
@@ -310,6 +311,7 @@ class TestEGO(SMTestCase):
         )
         self.assertAlmostEqual(0.494, float(y_opt), delta=1)
 
+    @unittest.skipIf(int(os.getenv("RUN_SLOW", 0)) < 1, "too slow")
     def test_branin_2D_mixed_tunnel(self):
         n_iter = 20
         fun = Branin(ndim=2)
@@ -368,6 +370,7 @@ class TestEGO(SMTestCase):
         )
         return y
 
+    @unittest.skipIf(int(os.getenv("RUN_SLOW", 0)) < 1, "too slow")
     def test_ego_mixed_integer(self):
         n_iter = 15
         xtypes = [FLOAT, (ENUM, 3), (ENUM, 2), ORD]
@@ -398,6 +401,7 @@ class TestEGO(SMTestCase):
 
         self.assertAlmostEqual(-15, float(y_opt), delta=5)
 
+    @unittest.skipIf(int(os.getenv("RUN_SLOW", 0)) < 1, "too slow")
     def test_ego_mixed_integer_gower_distance(self):
         n_iter = 15
         xtypes = [FLOAT, (ENUM, 3), (ENUM, 2), ORD]
@@ -432,6 +436,7 @@ class TestEGO(SMTestCase):
 
         self.assertAlmostEqual(-15, float(y_opt), delta=5)
 
+    @unittest.skipIf(int(os.getenv("RUN_SLOW", 0)) < 1, "too slow")
     def test_ego_mixed_integer_homo_gaussian(self):
         n_iter = 15
         xtypes = [FLOAT, (ENUM, 3), (ENUM, 2), ORD]
@@ -467,6 +472,7 @@ class TestEGO(SMTestCase):
 
         self.assertAlmostEqual(-15, float(y_opt), delta=5)
 
+    @unittest.skipIf(int(os.getenv("RUN_SLOW", 0)) < 1, "too slow")
     def test_ego_mixed_integer_homo_gaussian_pls(self):
         n_iter = 15
         xtypes = [FLOAT, (ENUM, 3), (ENUM, 2), ORD]

--- a/smt/sampling_methods/tests/test_lhs.py
+++ b/smt/sampling_methods/tests/test_lhs.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 import numpy as np
 
@@ -32,6 +33,7 @@ class Test(unittest.TestCase):
         self.assertTrue(np.allclose(doe1, doe3))
         self.assertTrue(np.allclose(doe2, doe4))
 
+    @unittest.skipIf(int(os.getenv("RUN_SLOW", 0)) < 1, "too slow")
     def test_expand_lhs(self):
         import numpy as np
 

--- a/smt/tests/test_all.py
+++ b/smt/tests/test_all.py
@@ -5,6 +5,7 @@ Author: Dr. John T. Hwang <hwangjt@umich.edu>
 This package is distributed under New BSD license.
 """
 
+import os
 import numpy as np
 import unittest
 import inspect
@@ -216,6 +217,7 @@ class Test(SMTestCase):
     def test_exp_GEKPLS_TNC(self):
         self.run_test()
 
+    @unittest.skipIf(int(os.getenv("RUN_SLOW", 0)) < 1, "too slow")
     def test_exp_GENN(self):
         self.run_test()
 
@@ -271,6 +273,7 @@ class Test(SMTestCase):
     def test_tanh_GEKPLS_TNC(self):
         self.run_test()
 
+    @unittest.skipIf(int(os.getenv("RUN_SLOW", 0)) < 1, "too slow")
     def test_tanh_GENN(self):
         self.run_test()
 
@@ -326,6 +329,7 @@ class Test(SMTestCase):
     def test_cos_GEKPLS_TNC(self):
         self.run_test()
 
+    @unittest.skipIf(int(os.getenv("RUN_SLOW", 0)) < 1, "too slow")
     def test_cos_GENN(self):
         self.run_test()
 

--- a/smt/tests/test_high_dim.py
+++ b/smt/tests/test_high_dim.py
@@ -4,6 +4,7 @@ Author: Dr. John T. Hwang <hwangjt@umich.edu>
 This package is distributed under New BSD license.
 """
 
+import os
 import numpy as np
 import unittest
 import inspect
@@ -121,6 +122,7 @@ class Test(SMTestCase):
     def test_sphere_QP(self):
         self.run_test()
 
+    @unittest.skipIf(int(os.getenv("RUN_SLOW", 0)) < 1, "too slow")
     def test_sphere_KRG(self):
         self.run_test()
 
@@ -144,6 +146,7 @@ class Test(SMTestCase):
     def test_exp_QP(self):
         self.run_test()
 
+    @unittest.skipIf(int(os.getenv("RUN_SLOW", 0)) < 1, "too slow")
     def test_exp_KRG(self):
         self.run_test()
 
@@ -167,6 +170,7 @@ class Test(SMTestCase):
     def test_tanh_QP(self):
         self.run_test()
 
+    @unittest.skipIf(int(os.getenv("RUN_SLOW", 0)) < 1, "too slow")
     def test_tanh_KRG(self):
         self.run_test()
 
@@ -190,6 +194,7 @@ class Test(SMTestCase):
     def test_cos_QP(self):
         self.run_test()
 
+    @unittest.skipIf(int(os.getenv("RUN_SLOW", 0)) < 1, "too slow")
     def test_cos_KRG(self):
         self.run_test()
 


### PR DESCRIPTION
This PR to avoid running expensive tests by default to get feedback from CI more rapidly.

To run slow tests just set the environment variable `RUN_SLOW=1`.

CI is updated to run all tests only for coverage.

