### PR TITLE
Replace constants used for enumerations by native Python enums

### DIFF
--- a/smt/applications/ego.py
+++ b/smt/applications/ego.py
@@ -14,17 +14,7 @@ from scipy.optimize import minimize
 
 from smt.utils.mixed_integer import XType
 from smt.sampling_methods import LHS
-from smt.surrogate_models import (
-    KPLS,
-    KRG,
-    KPLSK,
-    MGP,
-    GEKPLS,
-    GOWER_KERNEL,
-    EXP_HOMO_HSPHERE_KERNEL,
-    HOMO_HSPHERE_KERNEL,
-    CONT_RELAX_KERNEL,
-)
+from smt.surrogate_models import KPLS, KRG, KPLSK, MGP, GEKPLS, MixIntKernelType
 from smt.applications.application import SurrogateBasedApplication
 from smt.applications.mixed_integer import (
     MixedIntegerContext,

--- a/smt/applications/ego.py
+++ b/smt/applications/ego.py
@@ -12,7 +12,7 @@ from types import FunctionType
 from scipy.stats import norm
 from scipy.optimize import minimize
 
-from smt.utils.mixed_integer import ORD_TYPE, ENUM_TYPE, FLOAT_TYPE
+from smt.utils.mixed_integer import XType
 from smt.sampling_methods import LHS
 from smt.surrogate_models import (
     KPLS,
@@ -268,7 +268,7 @@ class EGO(SurrogateBasedApplication):
         # Handle mixed integer optimization
         self.work_in_folded_space = self.gpr.options["categorical_kernel"] is not None
 
-        if self.gpr.options["xspecs"].types != [FLOAT_TYPE] * len(
+        if self.gpr.options["xspecs"].types != [XType.FLOAT] * len(
             self.gpr.options["xspecs"].limits
         ):
             self.xtypes = self.gpr.options["xspecs"].types

--- a/smt/applications/mixed_integer.py
+++ b/smt/applications/mixed_integer.py
@@ -24,11 +24,7 @@ from smt.surrogate_models.krg_based import (
     CONT_RELAX_KERNEL,
 )
 from smt.utils.mixed_integer import XType
-from smt.utils.kriging import (
-    DECREED_ROLE,
-    META_ROLE,
-    NEUTRAL_ROLE,
-)
+from smt.utils.kriging import XRole
 import warnings
 
 
@@ -120,7 +116,7 @@ class MixedIntegerSurrogateModel(SurrogateModel):
                 + " is not supported. Please use MixedIntegerKrigingModel instead."
             )
         self._xspecs = xspecs
-        if META_ROLE in xspecs.roles:
+        if XRole.META in xspecs.roles:
             raise ValueError(
                 "Using MixedIntegerSurrogateModel integer model with hierarchical variables is not supported. Please use MixedIntegerKrigingModel instead."
             )
@@ -225,7 +221,7 @@ class MixedIntegerKrigingModel(KrgBased):
             if self._surrogate.options["poly"] != "constant":
                 raise ValueError("constant regression must be used with mixed integer")
 
-        if (META_ROLE in self._xspecs.roles) and self._surrogate.options[
+        if (XRole.META in self._xspecs.roles) and self._surrogate.options[
             "categorical_kernel"
         ] is None:
             self._surrogate.options["categorical_kernel"] = HOMO_HSPHERE_KERNEL

--- a/smt/applications/mixed_integer.py
+++ b/smt/applications/mixed_integer.py
@@ -23,11 +23,7 @@ from smt.surrogate_models.krg_based import (
     EXP_HOMO_HSPHERE_KERNEL,
     CONT_RELAX_KERNEL,
 )
-from smt.utils.mixed_integer import (
-    ORD_TYPE,
-    ENUM_TYPE,
-    FLOAT_TYPE,
-)
+from smt.utils.mixed_integer import XType
 from smt.utils.kriging import (
     DECREED_ROLE,
     META_ROLE,

--- a/smt/applications/mixed_integer.py
+++ b/smt/applications/mixed_integer.py
@@ -16,13 +16,7 @@ from smt.utils.mixed_integer import (
     unfold_with_enum_mask,
     unfold_xlimits_with_continuous_limits,
 )
-from smt.surrogate_models.krg_based import (
-    KrgBased,
-    GOWER_KERNEL,
-    HOMO_HSPHERE_KERNEL,
-    EXP_HOMO_HSPHERE_KERNEL,
-    CONT_RELAX_KERNEL,
-)
+from smt.surrogate_models.krg_based import KrgBased, MixIntKernelType
 from smt.utils.mixed_integer import XType
 from smt.utils.kriging import XRole
 import warnings
@@ -224,7 +218,9 @@ class MixedIntegerKrigingModel(KrgBased):
         if (XRole.META in self._xspecs.roles) and self._surrogate.options[
             "categorical_kernel"
         ] is None:
-            self._surrogate.options["categorical_kernel"] = HOMO_HSPHERE_KERNEL
+            self._surrogate.options[
+                "categorical_kernel"
+            ] = MixIntKernelType.HOMO_HSPHERE
             warnings.warn(
                 "Using MixedIntegerSurrogateModel integer model with Continuous Relaxation is not supported. Switched to homoscedastic hypersphere kernel instead."
             )

--- a/smt/applications/tests/test_ego.py
+++ b/smt/applications/tests/test_ego.py
@@ -30,9 +30,7 @@ from smt.surrogate_models import (
     XSpecs,
     XType,
     XRole,
-    HOMO_HSPHERE_KERNEL,
-    EXP_HOMO_HSPHERE_KERNEL,
-    GOWER_KERNEL,
+    MixIntKernelType,
 )
 from smt.applications.mixed_integer import (
     MixedIntegerContext,
@@ -400,7 +398,9 @@ class TestEGO(SMTestCase):
             criterion=criterion,
             xdoe=xdoe,
             surrogate=KRG(
-                xspecs=xspecs, categorical_kernel=GOWER_KERNEL, print_global=False
+                xspecs=xspecs,
+                categorical_kernel=MixIntKernelType.GOWER,
+                print_global=False,
             ),
             enable_tunneling=False,
             random_state=42,
@@ -517,7 +517,7 @@ class TestEGO(SMTestCase):
             xdoe=Xt,
             surrogate=KRG(
                 xspecs=xspecs,
-                categorical_kernel=HOMO_HSPHERE_KERNEL,
+                categorical_kernel=MixIntKernelType.HOMO_HSPHERE,
                 theta0=[1e-2],
                 n_start=5,
                 corr="abs_exp",
@@ -695,7 +695,7 @@ class TestEGO(SMTestCase):
             xdoe=Xt,
             surrogate=KRG(
                 xspecs=xspecs,
-                categorical_kernel=HOMO_HSPHERE_KERNEL,
+                categorical_kernel=MixIntKernelType.HOMO_HSPHERE,
                 theta0=[1e-2],
                 n_start=5,
                 corr="squar_exp",
@@ -739,7 +739,7 @@ class TestEGO(SMTestCase):
             xdoe=xdoe,
             surrogate=KRG(
                 xspecs=xspecs,
-                categorical_kernel=EXP_HOMO_HSPHERE_KERNEL,
+                categorical_kernel=MixIntKernelType.EXP_HOMO_HSPHERE,
                 print_global=False,
             ),
             enable_tunneling=False,
@@ -771,7 +771,7 @@ class TestEGO(SMTestCase):
         sm = KPLS(
             print_global=False,
             xspecs=xspecs,
-            categorical_kernel=EXP_HOMO_HSPHERE_KERNEL,
+            categorical_kernel=MixIntKernelType.EXP_HOMO_HSPHERE,
             n_comp=1,
             cat_kernel_comps=[2, 2],
         )
@@ -1020,7 +1020,7 @@ class TestEGO(SMTestCase):
         from smt.applications.mixed_integer import MixedIntegerContext
         from smt.surrogate_models import (
             XType,
-            GOWER_KERNEL,
+            MixIntKernelType,
             XSpecs,
         )
         import matplotlib.pyplot as plt
@@ -1063,7 +1063,9 @@ class TestEGO(SMTestCase):
 
         criterion = "EI"  #'EI' or 'SBO' or 'LCB'
         qEI = "KBRand"
-        sm = KRG(xspecs=xspecs, categorical_kernel=GOWER_KERNEL, print_global=False)
+        sm = KRG(
+            xspecs=xspecs, categorical_kernel=MixIntKernelType.GOWER, print_global=False
+        )
         mixint = MixedIntegerContext(xspecs)
         n_doe = 3
         sampling = mixint.build_sampling_method(LHS, criterion="ese", random_state=42)

--- a/smt/applications/tests/test_ego.py
+++ b/smt/applications/tests/test_ego.py
@@ -29,9 +29,7 @@ from smt.surrogate_models import (
     KPLS,
     XSpecs,
     XType,
-    NEUTRAL_ROLE,
-    META_ROLE,
-    DECREED_ROLE,
+    XRole,
     HOMO_HSPHERE_KERNEL,
     EXP_HOMO_HSPHERE_KERNEL,
     GOWER_KERNEL,
@@ -442,14 +440,14 @@ class TestEGO(SMTestCase):
             return np.array(y)
 
         xlimits = [
-            [1, 3],  # META_ROLE XType.ORD
+            [1, 3],  # XRole.META XType.ORD
             [-5, -2],
             [-5, -1],
             ["8", "16", "32", "64", "128", "256"],
             ["ReLU", "SELU", "ISRLU"],
-            [0.0, 5.0],  # DECREED_ROLE m=1
-            [0.0, 5.0],  # DECREED_ROLE m=2
-            [0.0, 5.0],  # DECREED_ROLE m=3
+            [0.0, 5.0],  # XRole.DECREED m=1
+            [0.0, 5.0],  # XRole.DECREED m=2
+            [0.0, 5.0],  # XRole.DECREED m=3
         ]
         xtypes = [
             XType.ORD,
@@ -462,14 +460,14 @@ class TestEGO(SMTestCase):
             XType.ORD,
         ]
         xroles = [
-            META_ROLE,
-            NEUTRAL_ROLE,
-            NEUTRAL_ROLE,
-            NEUTRAL_ROLE,
-            NEUTRAL_ROLE,
-            DECREED_ROLE,
-            DECREED_ROLE,
-            DECREED_ROLE,
+            XRole.META,
+            XRole.NEUTRAL,
+            XRole.NEUTRAL,
+            XRole.NEUTRAL,
+            XRole.NEUTRAL,
+            XRole.DECREED,
+            XRole.DECREED,
+            XRole.DECREED,
         ]
         xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits, xroles=xroles)
         n_doe = 4
@@ -641,7 +639,7 @@ class TestEGO(SMTestCase):
             return np.array(y)
 
         xlimits = [
-            ["6,7", "3,7", "4,6", "3,4"],  # META_ROLE1 XType.ORD
+            ["6,7", "3,7", "4,6", "3,4"],  # XRole.META1 XType.ORD
             [0, 1],  # 0
             [0, 100],  # 1
             [0, 100],  # 2
@@ -654,17 +652,17 @@ class TestEGO(SMTestCase):
             [0, 2],  # 9
         ]
         xroles = [
-            META_ROLE,
-            NEUTRAL_ROLE,
-            NEUTRAL_ROLE,
-            NEUTRAL_ROLE,
-            DECREED_ROLE,
-            DECREED_ROLE,
-            NEUTRAL_ROLE,
-            DECREED_ROLE,
-            DECREED_ROLE,
-            NEUTRAL_ROLE,
-            NEUTRAL_ROLE,
+            XRole.META,
+            XRole.NEUTRAL,
+            XRole.NEUTRAL,
+            XRole.NEUTRAL,
+            XRole.DECREED,
+            XRole.DECREED,
+            XRole.NEUTRAL,
+            XRole.DECREED,
+            XRole.DECREED,
+            XRole.NEUTRAL,
+            XRole.NEUTRAL,
         ]
         # z or x, cos?;          x1,x2,          x3, x4,        x5:cos,       z1,z2;            exp1,exp2
 

--- a/smt/applications/tests/test_ego.py
+++ b/smt/applications/tests/test_ego.py
@@ -23,13 +23,11 @@ from smt.problems import Branin, Rosenbrock
 from smt.sampling_methods import FullFactorial
 from multiprocessing import Pool
 from smt.sampling_methods import LHS
-import itertools
 from smt.surrogate_models import (
     KRG,
     GEKPLS,
     KPLS,
     XSpecs,
-    QP,
     XType,
     NEUTRAL_ROLE,
     META_ROLE,

--- a/smt/applications/tests/test_ego.py
+++ b/smt/applications/tests/test_ego.py
@@ -30,9 +30,7 @@ from smt.surrogate_models import (
     KPLS,
     XSpecs,
     QP,
-    FLOAT_TYPE,
-    ORD_TYPE,
-    ENUM_TYPE,
+    XType,
     NEUTRAL_ROLE,
     META_ROLE,
     DECREED_ROLE,
@@ -241,7 +239,7 @@ class TestEGO(SMTestCase):
         xlimits = fun.xlimits
         criterion = "EI"  #'EI' or 'SBO' or 'LCB'
         qEI = "CLmin"
-        xtypes = [ORD_TYPE, FLOAT_TYPE]
+        xtypes = [XType.ORD, XType.FLOAT]
         xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
         sm = KRG(xspecs=xspecs, print_global=False)
         mixint = MixedIntegerContext(xspecs)
@@ -272,7 +270,7 @@ class TestEGO(SMTestCase):
     def test_branin_2D_mixed(self):
         n_iter = 20
         fun = Branin(ndim=2)
-        xtypes = [ORD_TYPE, FLOAT_TYPE]
+        xtypes = [XType.ORD, XType.FLOAT]
         xlimits = fun.xlimits
         xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
         criterion = "EI"  #'EI' or 'SBO' or 'LCB'
@@ -303,7 +301,7 @@ class TestEGO(SMTestCase):
     def test_branin_2D_mixed_tunnel(self):
         n_iter = 20
         fun = Branin(ndim=2)
-        xtypes = [ORD_TYPE, FLOAT_TYPE]
+        xtypes = [XType.ORD, XType.FLOAT]
         xlimits = fun.xlimits
         xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
         criterion = "EI"  #'EI' or 'SBO' or 'LCB'
@@ -336,12 +334,12 @@ class TestEGO(SMTestCase):
 
         # float
         x1 = X[:, 0]
-        #  ENUM_TYPE 1
+        #  XType.ENUM 1
         c1 = X[:, 1]
         x2 = c1 == 0
         x3 = c1 == 1
         x4 = c1 == 2
-        #  ENUM_TYPE 2
+        #  XType.ENUM 2
         c2 = X[:, 2]
         x5 = c2 == 0
         x6 = c2 == 1
@@ -358,7 +356,7 @@ class TestEGO(SMTestCase):
     @unittest.skipIf(int(os.getenv("RUN_SLOW", 0)) < 1, "too slow")
     def test_ego_mixed_integer(self):
         n_iter = 15
-        xtypes = [FLOAT_TYPE, (ENUM_TYPE, 3), (ENUM_TYPE, 2), ORD_TYPE]
+        xtypes = [XType.FLOAT, (XType.ENUM, 3), (XType.ENUM, 2), XType.ORD]
         xlimits = np.array(
             [[-5, 5], ["blue", "red", "green"], ["large", "small"], ["0", "2", "3"]],
             dtype="object",
@@ -385,7 +383,7 @@ class TestEGO(SMTestCase):
     @unittest.skipIf(int(os.getenv("RUN_SLOW", 0)) < 1, "too slow")
     def test_ego_mixed_integer_gower_distance(self):
         n_iter = 15
-        xtypes = [FLOAT_TYPE, (ENUM_TYPE, 3), (ENUM_TYPE, 2), ORD_TYPE]
+        xtypes = [XType.FLOAT, (XType.ENUM, 3), (XType.ENUM, 2), XType.ORD]
         xlimits = np.array(
             [[-5, 5], ["blue", "red", "green"], ["large", "small"], [0, 2]],
             dtype="object",
@@ -446,7 +444,7 @@ class TestEGO(SMTestCase):
             return np.array(y)
 
         xlimits = [
-            [1, 3],  # META_ROLE ORD_TYPE
+            [1, 3],  # META_ROLE XType.ORD
             [-5, -2],
             [-5, -1],
             ["8", "16", "32", "64", "128", "256"],
@@ -456,14 +454,14 @@ class TestEGO(SMTestCase):
             [0.0, 5.0],  # DECREED_ROLE m=3
         ]
         xtypes = [
-            ORD_TYPE,
-            FLOAT_TYPE,
-            FLOAT_TYPE,
-            ORD_TYPE,
-            (ENUM_TYPE, 3),
-            ORD_TYPE,
-            ORD_TYPE,
-            ORD_TYPE,
+            XType.ORD,
+            XType.FLOAT,
+            XType.FLOAT,
+            XType.ORD,
+            (XType.ENUM, 3),
+            XType.ORD,
+            XType.ORD,
+            XType.ORD,
         ]
         xroles = [
             META_ROLE,
@@ -645,7 +643,7 @@ class TestEGO(SMTestCase):
             return np.array(y)
 
         xlimits = [
-            ["6,7", "3,7", "4,6", "3,4"],  # META_ROLE1 ORD_TYPE
+            ["6,7", "3,7", "4,6", "3,4"],  # META_ROLE1 XType.ORD
             [0, 1],  # 0
             [0, 100],  # 1
             [0, 100],  # 2
@@ -673,17 +671,17 @@ class TestEGO(SMTestCase):
         # z or x, cos?;          x1,x2,          x3, x4,        x5:cos,       z1,z2;            exp1,exp2
 
         xtypes = [
-            (ENUM_TYPE, 4),
-            ORD_TYPE,
-            FLOAT_TYPE,
-            FLOAT_TYPE,
-            FLOAT_TYPE,
-            FLOAT_TYPE,
-            FLOAT_TYPE,
-            ORD_TYPE,
-            ORD_TYPE,
-            ORD_TYPE,
-            ORD_TYPE,
+            (XType.ENUM, 4),
+            XType.ORD,
+            XType.FLOAT,
+            XType.FLOAT,
+            XType.FLOAT,
+            XType.FLOAT,
+            XType.FLOAT,
+            XType.ORD,
+            XType.ORD,
+            XType.ORD,
+            XType.ORD,
         ]
         xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits, xroles=xroles)
         n_doe = 15
@@ -722,7 +720,7 @@ class TestEGO(SMTestCase):
 
     def test_ego_mixed_integer_homo_gaussian(self):
         n_iter = 15
-        xtypes = [FLOAT_TYPE, (ENUM_TYPE, 3), (ENUM_TYPE, 2), ORD_TYPE]
+        xtypes = [XType.FLOAT, (XType.ENUM, 3), (XType.ENUM, 2), XType.ORD]
         xlimits = np.array(
             [[-5, 5], ["blue", "red", "green"], ["large", "small"], [0, 2]],
             dtype="object",
@@ -758,7 +756,7 @@ class TestEGO(SMTestCase):
     @unittest.skipIf(int(os.getenv("RUN_SLOW", 0)) < 1, "too slow")
     def test_ego_mixed_integer_homo_gaussian_pls(self):
         n_iter = 15
-        xtypes = [FLOAT_TYPE, (ENUM_TYPE, 3), (ENUM_TYPE, 2), ORD_TYPE]
+        xtypes = [XType.FLOAT, (XType.ENUM, 3), (XType.ENUM, 2), XType.ORD]
         xlimits = np.array(
             [[-5, 5], ["blue", "red", "green"], ["large", "small"], [0, 2]],
             dtype="object",
@@ -1025,9 +1023,7 @@ class TestEGO(SMTestCase):
         from smt.applications import EGO
         from smt.applications.mixed_integer import MixedIntegerContext
         from smt.surrogate_models import (
-            FLOAT_TYPE,
-            ENUM_TYPE,
-            ORD_TYPE,
+            XType,
             GOWER_KERNEL,
             XSpecs,
         )
@@ -1062,7 +1058,7 @@ class TestEGO(SMTestCase):
             return y.reshape((-1, 1))
 
         n_iter = 15
-        xtypes = [FLOAT_TYPE, (ENUM_TYPE, 3), (ENUM_TYPE, 2), ORD_TYPE]
+        xtypes = [XType.FLOAT, (XType.ENUM, 3), (XType.ENUM, 2), XType.ORD]
         xlimits = np.array(
             [[-5, 5], ["red", "green", "blue"], ["square", "circle"], [0, 2]],
             dtype="object",

--- a/smt/applications/tests/test_mixed_integer.py
+++ b/smt/applications/tests/test_mixed_integer.py
@@ -33,9 +33,7 @@ from smt.surrogate_models import (
     KRG,
     KPLS,
     QP,
-    FLOAT_TYPE,
-    ORD_TYPE,
-    ENUM_TYPE,
+    XType,
     NEUTRAL_ROLE,
     META_ROLE,
     DECREED_ROLE,
@@ -47,7 +45,7 @@ from smt.surrogate_models import (
 
 class TestMixedInteger(unittest.TestCase):
     def test_krg_mixed_3D_INT(self):
-        xtypes = [FLOAT_TYPE, (ENUM_TYPE, 3), ORD_TYPE]
+        xtypes = [XType.FLOAT, (XType.ENUM, 3), XType.ORD]
         xlimits = [[-10, 10], ["blue", "red", "green"], [-10, 10]]
         xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
 
@@ -71,7 +69,7 @@ class TestMixedInteger(unittest.TestCase):
         self.assertTrue(eq_check)
 
     def test_krg_mixed_3D(self):
-        xtypes = [FLOAT_TYPE, (ENUM_TYPE, 3), ORD_TYPE]
+        xtypes = [XType.FLOAT, (XType.ENUM, 3), XType.ORD]
         xlimits = [[-10, 10], ["blue", "red", "green"], [-10, 10]]
         xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
 
@@ -95,7 +93,7 @@ class TestMixedInteger(unittest.TestCase):
         self.assertTrue(eq_check)
 
     def test_krg_mixed_3D_bad_regr(self):
-        xtypes = [FLOAT_TYPE, (ENUM_TYPE, 3), ORD_TYPE]
+        xtypes = [XType.FLOAT, (XType.ENUM, 3), XType.ORD]
         xlimits = [[-10, 10], ["blue", "red", "green"], [-10, 10]]
         xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
 
@@ -104,7 +102,7 @@ class TestMixedInteger(unittest.TestCase):
             sm = mixint.build_kriging_model(KRG(print_prediction=False, poly="linear"))
 
     def test_qp_mixed_2D_INT(self):
-        xtypes = [FLOAT_TYPE, ORD_TYPE]
+        xtypes = [XType.FLOAT, XType.ORD]
         xlimits = [[-10, 10], [-10, 10]]
         xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
 
@@ -125,29 +123,29 @@ class TestMixedInteger(unittest.TestCase):
         self.assertTrue(eq_check)
 
     def test_compute_unfolded_dimension(self):
-        xtypes = [FLOAT_TYPE, (ENUM_TYPE, 2)]
+        xtypes = [XType.FLOAT, (XType.ENUM, 2)]
         self.assertEqual(3, compute_unfolded_dimension(xtypes))
 
     def test_unfold_with_enum_mask(self):
-        xtypes = [FLOAT_TYPE, (ENUM_TYPE, 2)]
+        xtypes = [XType.FLOAT, (XType.ENUM, 2)]
         x = np.array([[1.5, 1], [1.5, 0], [1.5, 1]])
         expected = [[1.5, 0, 1], [1.5, 1, 0], [1.5, 0, 1]]
         self.assertListEqual(expected, unfold_with_enum_mask(xtypes, x).tolist())
 
     def test_unfold_with_enum_mask_with_enum_first(self):
-        xtypes = [(ENUM_TYPE, 2), FLOAT_TYPE]
+        xtypes = [(XType.ENUM, 2), XType.FLOAT]
         x = np.array([[1, 1.5], [0, 1.5], [1, 1.5]])
         expected = [[0, 1, 1.5], [1, 0, 1.5], [0, 1, 1.5]]
         self.assertListEqual(expected, unfold_with_enum_mask(xtypes, x).tolist())
 
     def test_fold_with_enum_index(self):
-        xtypes = [FLOAT_TYPE, (ENUM_TYPE, 2)]
+        xtypes = [XType.FLOAT, (XType.ENUM, 2)]
         x = np.array([[1.5, 0, 1], [1.5, 1, 0], [1.5, 0, 1]])
         expected = [[1.5, 1], [1.5, 0], [1.5, 1]]
         self.assertListEqual(expected, fold_with_enum_index(xtypes, x).tolist())
 
     def test_fold_with_enum_index_with_list(self):
-        xtypes = [FLOAT_TYPE, (ENUM_TYPE, 2)]
+        xtypes = [XType.FLOAT, (XType.ENUM, 2)]
         expected = [[1.5, 1]]
         x = np.array([1.5, 0, 1])
         self.assertListEqual(expected, fold_with_enum_index(xtypes, x).tolist())
@@ -162,7 +160,7 @@ class TestMixedInteger(unittest.TestCase):
         self.assertListEqual(expected, cast_to_enum_value(xlimits, x_col, enum_indexes))
 
     def test_unfolded_xlimits_type(self):
-        xtypes = [FLOAT_TYPE, (ENUM_TYPE, 2), (ENUM_TYPE, 2), ORD_TYPE]
+        xtypes = [XType.FLOAT, (XType.ENUM, 2), (XType.ENUM, 2), XType.ORD]
         xlimits = np.array([[-5, 5], ["2", "3"], ["4", "5"], [0, 2]])
         xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
         sampling = MixedIntegerSamplingMethod(LHS, xspecs, criterion="ese")
@@ -170,7 +168,7 @@ class TestMixedInteger(unittest.TestCase):
         self.assertEqual((10, 4), doe.shape)
 
     def test_cast_to_mixed_integer(self):
-        xtypes = [FLOAT_TYPE, (ENUM_TYPE, 2), (ENUM_TYPE, 3), ORD_TYPE]
+        xtypes = [XType.FLOAT, (XType.ENUM, 2), (XType.ENUM, 3), XType.ORD]
         xlimits = np.array(
             [[-5, 5], ["blue", "red"], ["short", "medium", "long"], [0, 2]],
             dtype="object",
@@ -181,7 +179,7 @@ class TestMixedInteger(unittest.TestCase):
         self.assertEqual([1.5, "blue", "long", 1], cast_to_mixed_integer(xspecs, x))
 
     def test_encode_with_enum_index(self):
-        xtypes = [FLOAT_TYPE, (ENUM_TYPE, 2), (ENUM_TYPE, 3), ORD_TYPE]
+        xtypes = [XType.FLOAT, (XType.ENUM, 2), (XType.ENUM, 3), XType.ORD]
         xlimits = np.array(
             [[-5, 5], ["blue", "red"], ["short", "medium", "long"], [0, 2]],
             dtype="object",
@@ -198,7 +196,7 @@ class TestMixedInteger(unittest.TestCase):
         )
 
     def test_unfold_xlimits_with_continuous_limits(self):
-        xtypes = [FLOAT_TYPE, (ENUM_TYPE, 2), (ENUM_TYPE, 3), ORD_TYPE]
+        xtypes = [XType.FLOAT, (XType.ENUM, 2), (XType.ENUM, 3), XType.ORD]
         xlimits = np.array(
             [[-5, 5], ["blue", "red"], ["short", "medium", "long"], [0, 2]],
             dtype="object",
@@ -215,7 +213,7 @@ class TestMixedInteger(unittest.TestCase):
         )
 
     def test_unfold_xlimits_with_continuous_limits_and_ordinal_values(self):
-        xtypes = [FLOAT_TYPE, (ENUM_TYPE, 2), (ENUM_TYPE, 3), ORD_TYPE]
+        xtypes = [XType.FLOAT, (XType.ENUM, 2), (XType.ENUM, 3), XType.ORD]
         xlimits = np.array(
             [[-5, 5], ["blue", "red"], ["short", "medium", "long"], ["0", "3", "4"]],
             dtype="object",
@@ -233,7 +231,7 @@ class TestMixedInteger(unittest.TestCase):
         )
 
     def test_cast_to_discrete_values(self):
-        xtypes = [FLOAT_TYPE, (ENUM_TYPE, 2), (ENUM_TYPE, 3), ORD_TYPE]
+        xtypes = [XType.FLOAT, (XType.ENUM, 2), (XType.ENUM, 3), XType.ORD]
         xlimits = np.array(
             [[-5, 5], ["blue", "red"], ["short", "medium", "long"], [0, 4]],
             dtype="object",
@@ -251,7 +249,7 @@ class TestMixedInteger(unittest.TestCase):
         )
 
     def test_cast_to_discrete_values_with_smooth_rounding_ordinal_values(self):
-        xtypes = [FLOAT_TYPE, (ENUM_TYPE, 2), (ENUM_TYPE, 3), ORD_TYPE]
+        xtypes = [XType.FLOAT, (XType.ENUM, 2), (XType.ENUM, 3), XType.ORD]
 
         x = np.array([[2.6, 0.3, 0.5, 0.25, 0.45, 0.85, 3.1]])
         xlimits = np.array(
@@ -269,7 +267,7 @@ class TestMixedInteger(unittest.TestCase):
         )
 
     def test_cast_to_discrete_values_with_hard_rounding_ordinal_values(self):
-        xtypes = [FLOAT_TYPE, (ENUM_TYPE, 2), (ENUM_TYPE, 3), ORD_TYPE]
+        xtypes = [XType.FLOAT, (XType.ENUM, 2), (XType.ENUM, 3), XType.ORD]
 
         x = np.array([[2.6, 0.3, 0.5, 0.25, 0.45, 0.85, 3.1]])
         xlimits = np.array(
@@ -287,7 +285,7 @@ class TestMixedInteger(unittest.TestCase):
         )
 
     def test_cast_to_discrete_values_with_non_integer_ordinal_values(self):
-        xtypes = [FLOAT_TYPE, (ENUM_TYPE, 2), (ENUM_TYPE, 3), ORD_TYPE]
+        xtypes = [XType.FLOAT, (XType.ENUM, 2), (XType.ENUM, 3), XType.ORD]
 
         x = np.array([[2.6, 0.3, 0.5, 0.25, 0.45, 0.85, 3.1]])
         xlimits = np.array(
@@ -315,10 +313,10 @@ class TestMixedInteger(unittest.TestCase):
         from matplotlib import colors
 
         from smt.sampling_methods import LHS
-        from smt.surrogate_models import FLOAT_TYPE, ENUM_TYPE, XSpecs
+        from smt.surrogate_models import XType, XSpecs
         from smt.applications.mixed_integer import MixedIntegerSamplingMethod
 
-        xtypes = [FLOAT_TYPE, (ENUM_TYPE, 2)]
+        xtypes = [XType.FLOAT, (XType.ENUM, 2)]
         xlimits = [[0.0, 4.0], ["blue", "red"]]
         xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
 
@@ -335,18 +333,18 @@ class TestMixedInteger(unittest.TestCase):
         import numpy as np
         import matplotlib.pyplot as plt
 
-        from smt.surrogate_models import QP, ORD_TYPE, XSpecs
+        from smt.surrogate_models import QP, XType, XSpecs
         from smt.applications.mixed_integer import MixedIntegerSurrogateModel
 
         xt = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
         yt = np.array([0.0, 1.0, 1.5, 0.5, 1.0])
 
-        # xtypes = [FLOAT_TYPE, ORD_TYPE, (ENUM, 3), (ENUM, 2)]
-        # FLOAT_TYPE means x1 continuous
-        # ORD_TYPE means x2 ordered
+        # xtypes = [XType.FLOAT, XType.ORD, (ENUM, 3), (ENUM, 2)]
+        # XType.FLOAT means x1 continuous
+        # XType.ORD means x2 ordered
         # (ENUM, 3) means x3, x4 & x5 are 3 levels of the same categorical variable
         # (ENUM, 2) means x6 & x7 are 2 levels of the same categorical variable
-        xspecs = XSpecs(xtypes=[ORD_TYPE], xlimits=[[0, 4]])
+        xspecs = XSpecs(xtypes=[XType.ORD], xlimits=[[0, 4]])
         sm = MixedIntegerSurrogateModel(xspecs=xspecs, surrogate=QP())
         sm.set_training_values(xt, yt)
         sm.train()
@@ -369,10 +367,10 @@ class TestMixedInteger(unittest.TestCase):
         from mpl_toolkits.mplot3d import Axes3D
 
         from smt.sampling_methods import LHS, Random
-        from smt.surrogate_models import KRG, FLOAT_TYPE, ORD_TYPE, ENUM_TYPE, XSpecs
+        from smt.surrogate_models import KRG, XType, XSpecs
         from smt.applications.mixed_integer import MixedIntegerContext
 
-        xtypes = [ORD_TYPE, FLOAT_TYPE, (ENUM_TYPE, 4)]
+        xtypes = [XType.ORD, XType.FLOAT, (XType.ENUM, 4)]
         xlimits = [[0, 5], [0.0, 4.0], ["blue", "red", "green", "yellow"]]
         xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
 
@@ -540,17 +538,17 @@ class TestMixedInteger(unittest.TestCase):
         # z or x, cos?;          x1,x2,          x3, x4,        x5:cos,       z1,z2;            exp1,exp2
 
         xtypes = [
-            (ENUM_TYPE, 4),
-            ORD_TYPE,
-            FLOAT_TYPE,
-            FLOAT_TYPE,
-            FLOAT_TYPE,
-            FLOAT_TYPE,
-            FLOAT_TYPE,
-            ORD_TYPE,
-            ORD_TYPE,
-            ORD_TYPE,
-            ORD_TYPE,
+            (XType.ENUM, 4),
+            XType.ORD,
+            XType.FLOAT,
+            XType.FLOAT,
+            XType.FLOAT,
+            XType.FLOAT,
+            XType.FLOAT,
+            XType.ORD,
+            XType.ORD,
+            XType.ORD,
+            XType.ORD,
         ]
         xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits, xroles=xroles)
         n_doe = 15
@@ -696,14 +694,14 @@ class TestMixedInteger(unittest.TestCase):
             [0.0, 5.0],  # decreed m=3
         ]
         xtypes = [
-            ORD_TYPE,
-            FLOAT_TYPE,
-            FLOAT_TYPE,
-            ORD_TYPE,
-            (ENUM_TYPE, 3),
-            ORD_TYPE,
-            ORD_TYPE,
-            ORD_TYPE,
+            XType.ORD,
+            XType.FLOAT,
+            XType.FLOAT,
+            XType.ORD,
+            (XType.ENUM, 3),
+            XType.ORD,
+            XType.ORD,
+            XType.ORD,
         ]
         xroles = [
             META_ROLE,
@@ -806,7 +804,7 @@ class TestMixedInteger(unittest.TestCase):
         xt = np.array([[0, 5], [2, -1], [4, 0.5]])
         yt = np.array([[0.0], [1.0], [1.5]])
         xlimits = [["0.0", "1.0", " 2.0", "3.0", "4.0"], [-5, 5]]
-        xtypes = [(ENUM_TYPE, 5), FLOAT_TYPE]
+        xtypes = [(XType.ENUM, 5), XType.FLOAT]
         xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
 
         # Surrogate
@@ -842,7 +840,7 @@ class TestMixedInteger(unittest.TestCase):
         xt = np.array([[0, 5], [2, -1], [4, 0.5]])
         yt = np.array([[0.0], [1.0], [1.5]])
         xlimits = [["0.0", "1.0", " 2.0", "3.0", "4.0"], [-5, 5]]
-        xtypes = [(ENUM_TYPE, 5), FLOAT_TYPE]
+        xtypes = [(XType.ENUM, 5), XType.FLOAT]
         xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
         # Surrogate
         sm = MixedIntegerKrigingModel(
@@ -877,7 +875,7 @@ class TestMixedInteger(unittest.TestCase):
         xt = np.array([[0, 5], [2, -1], [4, 0.5]])
         yt = np.array([[0.0], [1.0], [1.5]])
         xlimits = [["0.0", "1.0", " 2.0", "3.0", "4.0"], [-5, 5]]
-        xtypes = [(ENUM_TYPE, 5), FLOAT_TYPE]
+        xtypes = [(XType.ENUM, 5), XType.FLOAT]
         xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
         # Surrogate
         sm = MixedIntegerKrigingModel(
@@ -912,7 +910,7 @@ class TestMixedInteger(unittest.TestCase):
         xt = np.array([[0.5, 0, 5], [2, 3, 4], [5, 2, -1], [-2, 4, 0.5]])
         yt = np.array([[0.0], [3], [1.0], [1.5]])
         xlimits = [[-5, 5], ["0.0", "1.0", " 2.0", "3.0", "4.0"], [-5, 5]]
-        xtypes = [FLOAT_TYPE, (ENUM_TYPE, 5), FLOAT_TYPE]
+        xtypes = [XType.FLOAT, (XType.ENUM, 5), XType.FLOAT]
         xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
         # Surrogate
         sm = surrogate = KPLS(
@@ -946,7 +944,7 @@ class TestMixedInteger(unittest.TestCase):
         xt = np.array([[0.5, 0, 5], [2, 3, 4], [5, 2, -1], [-2, 4, 0.5]])
         yt = np.array([[0.0], [3], [1.0], [1.5]])
         xlimits = [[-5, 5], ["0.0", "1.0", " 2.0", "3.0", "4.0"], [-5, 5]]
-        xtypes = [FLOAT_TYPE, (ENUM_TYPE, 5), FLOAT_TYPE]
+        xtypes = [XType.FLOAT, (XType.ENUM, 5), XType.FLOAT]
         xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
         # Surrogate
         sm = KPLS(
@@ -981,7 +979,7 @@ class TestMixedInteger(unittest.TestCase):
         xt = np.array([[0.5, 0, 5], [2, 3, 4], [5, 2, -1], [-2, 4, 0.5]])
         yt = np.array([[0.0], [3], [1.0], [1.5]])
         xlimits = [[-5, 5], ["0.0", "1.0", " 2.0", "3.0", "4.0"], [-5, 5]]
-        xtypes = [FLOAT_TYPE, (ENUM_TYPE, 5), FLOAT_TYPE]
+        xtypes = [XType.FLOAT, (XType.ENUM, 5), XType.FLOAT]
         xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
         # Surrogate
         sm = MixedIntegerKrigingModel(
@@ -1021,7 +1019,7 @@ class TestMixedInteger(unittest.TestCase):
             [-5, 5],
             ["0.0", "1.0", " 2.0", "3.0"],
         ]
-        xtypes = [(ENUM_TYPE, 5), ORD_TYPE, (ENUM_TYPE, 4)]
+        xtypes = [(XType.ENUM, 5), XType.ORD, (XType.ENUM, 4)]
         xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
         # Surrogate
         sm = MixedIntegerKrigingModel(
@@ -1054,7 +1052,7 @@ class TestMixedInteger(unittest.TestCase):
         self.assertTrue((np.abs(np.sum(np.array(sm.predict_variances(xt) - 0)) < 1e-6)))
 
     def test_mixed_gower_3D(self):
-        xtypes = [FLOAT_TYPE, ORD_TYPE, ORD_TYPE]
+        xtypes = [XType.FLOAT, XType.ORD, XType.ORD]
         xlimits = [[-10, 10], [-10, 10], [-10, 10]]
         xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
         mixint = MixedIntegerContext(xspecs=xspecs)
@@ -1086,8 +1084,7 @@ class TestMixedInteger(unittest.TestCase):
 
         from smt.surrogate_models import (
             KRG,
-            ENUM_TYPE,
-            FLOAT_TYPE,
+            XType,
             XSpecs,
             GOWER_KERNEL,
         )
@@ -1105,7 +1102,7 @@ class TestMixedInteger(unittest.TestCase):
 
         yt = np.concatenate((yt1, yt2, yt3), axis=0)
         xlimits = [["Blue", "Red", "Green"], [0.0, 4.0]]
-        xtypes = [(ENUM_TYPE, 3), FLOAT_TYPE]
+        xtypes = [(XType.ENUM, 3), XType.FLOAT]
         xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
         # Surrogate
         sm = MixedIntegerKrigingModel(
@@ -1211,8 +1208,7 @@ class TestMixedInteger(unittest.TestCase):
 
         from smt.surrogate_models import (
             KRG,
-            ENUM_TYPE,
-            FLOAT_TYPE,
+            XType,
             XSpecs,
             EXP_HOMO_HSPHERE_KERNEL,
         )
@@ -1230,7 +1226,7 @@ class TestMixedInteger(unittest.TestCase):
 
         yt = np.concatenate((yt1, yt2, yt3), axis=0)
         xlimits = [["Blue", "Red", "Green"], [0.0, 4.0]]
-        xtypes = [(ENUM_TYPE, 3), FLOAT_TYPE]
+        xtypes = [(XType.ENUM, 3), XType.FLOAT]
         xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
         # Surrogate
         sm = MixedIntegerKrigingModel(
@@ -1336,8 +1332,7 @@ class TestMixedInteger(unittest.TestCase):
 
         from smt.surrogate_models import (
             KRG,
-            ENUM_TYPE,
-            FLOAT_TYPE,
+            XType,
             XSpecs,
             HOMO_HSPHERE_KERNEL,
         )
@@ -1355,7 +1350,7 @@ class TestMixedInteger(unittest.TestCase):
 
         yt = np.concatenate((yt1, yt2, yt3), axis=0)
         xlimits = [["Blue", "Red", "Green"], [0.0, 4.0]]
-        xtypes = [(ENUM_TYPE, 3), FLOAT_TYPE]
+        xtypes = [(XType.ENUM, 3), XType.FLOAT]
         xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits)
         # Surrogate
         sm = MixedIntegerKrigingModel(

--- a/smt/applications/tests/test_mixed_integer.py
+++ b/smt/applications/tests/test_mixed_integer.py
@@ -34,9 +34,7 @@ from smt.surrogate_models import (
     KPLS,
     QP,
     XType,
-    NEUTRAL_ROLE,
-    META_ROLE,
-    DECREED_ROLE,
+    XRole,
     GOWER_KERNEL,
     HOMO_HSPHERE_KERNEL,
     EXP_HOMO_HSPHERE_KERNEL,
@@ -523,17 +521,17 @@ class TestMixedInteger(unittest.TestCase):
             [0, 2],  # 9
         ]
         xroles = [
-            META_ROLE,
-            NEUTRAL_ROLE,
-            NEUTRAL_ROLE,
-            NEUTRAL_ROLE,
-            DECREED_ROLE,
-            DECREED_ROLE,
-            NEUTRAL_ROLE,
-            DECREED_ROLE,
-            DECREED_ROLE,
-            NEUTRAL_ROLE,
-            NEUTRAL_ROLE,
+            XRole.META,
+            XRole.NEUTRAL,
+            XRole.NEUTRAL,
+            XRole.NEUTRAL,
+            XRole.DECREED,
+            XRole.DECREED,
+            XRole.NEUTRAL,
+            XRole.DECREED,
+            XRole.DECREED,
+            XRole.NEUTRAL,
+            XRole.NEUTRAL,
         ]
         # z or x, cos?;          x1,x2,          x3, x4,        x5:cos,       z1,z2;            exp1,exp2
 
@@ -704,14 +702,14 @@ class TestMixedInteger(unittest.TestCase):
             XType.ORD,
         ]
         xroles = [
-            META_ROLE,
-            NEUTRAL_ROLE,
-            NEUTRAL_ROLE,
-            NEUTRAL_ROLE,
-            NEUTRAL_ROLE,
-            DECREED_ROLE,
-            DECREED_ROLE,
-            DECREED_ROLE,
+            XRole.META,
+            XRole.NEUTRAL,
+            XRole.NEUTRAL,
+            XRole.NEUTRAL,
+            XRole.NEUTRAL,
+            XRole.DECREED,
+            XRole.DECREED,
+            XRole.DECREED,
         ]
         xspecs = XSpecs(xtypes=xtypes, xlimits=xlimits, xroles=xroles)
         n_doe = 100

--- a/smt/applications/tests/test_mixed_integer.py
+++ b/smt/applications/tests/test_mixed_integer.py
@@ -35,9 +35,7 @@ from smt.surrogate_models import (
     QP,
     XType,
     XRole,
-    GOWER_KERNEL,
-    HOMO_HSPHERE_KERNEL,
-    EXP_HOMO_HSPHERE_KERNEL,
+    MixIntKernelType,
 )
 
 
@@ -559,7 +557,7 @@ class TestMixedInteger(unittest.TestCase):
         sm = MixedIntegerKrigingModel(
             surrogate=KRG(
                 xspecs=xspecs,
-                categorical_kernel=HOMO_HSPHERE_KERNEL,
+                categorical_kernel=MixIntKernelType.HOMO_HSPHERE,
                 theta0=[1e-2],
                 corr="abs_exp",
                 n_start=5,
@@ -751,7 +749,7 @@ class TestMixedInteger(unittest.TestCase):
         sm = MixedIntegerKrigingModel(
             surrogate=KRG(
                 xspecs=xspecs,
-                categorical_kernel=HOMO_HSPHERE_KERNEL,
+                categorical_kernel=MixIntKernelType.HOMO_HSPHERE,
                 theta0=[1e-2],
                 corr="abs_exp",
                 n_start=5,
@@ -811,7 +809,7 @@ class TestMixedInteger(unittest.TestCase):
                 xspecs=xspecs,
                 theta0=[1e-2],
                 corr="abs_exp",
-                categorical_kernel=GOWER_KERNEL,
+                categorical_kernel=MixIntKernelType.GOWER,
             ),
         )
         sm.set_training_values(xt, yt)
@@ -846,7 +844,7 @@ class TestMixedInteger(unittest.TestCase):
                 xspecs=xspecs,
                 theta0=[1e-2],
                 corr="abs_exp",
-                categorical_kernel=EXP_HOMO_HSPHERE_KERNEL,
+                categorical_kernel=MixIntKernelType.EXP_HOMO_HSPHERE,
             ),
         )
         sm.set_training_values(xt, yt)
@@ -880,7 +878,7 @@ class TestMixedInteger(unittest.TestCase):
             surrogate=KRG(
                 xspecs=xspecs,
                 theta0=[1e-2],
-                categorical_kernel=HOMO_HSPHERE_KERNEL,
+                categorical_kernel=MixIntKernelType.HOMO_HSPHERE,
                 corr="abs_exp",
             ),
         )
@@ -915,7 +913,7 @@ class TestMixedInteger(unittest.TestCase):
             xspecs=xspecs,
             theta0=[1e-2],
             n_comp=1,
-            categorical_kernel=EXP_HOMO_HSPHERE_KERNEL,
+            categorical_kernel=MixIntKernelType.EXP_HOMO_HSPHERE,
             cat_kernel_comps=[3],
             corr="squar_exp",
         )
@@ -951,7 +949,7 @@ class TestMixedInteger(unittest.TestCase):
             n_comp=2,
             corr="abs_exp",
             cat_kernel_comps=[3],
-            categorical_kernel=EXP_HOMO_HSPHERE_KERNEL,
+            categorical_kernel=MixIntKernelType.EXP_HOMO_HSPHERE,
         )
 
         sm.set_training_values(xt, yt)
@@ -985,7 +983,7 @@ class TestMixedInteger(unittest.TestCase):
                 xspecs=xspecs,
                 theta0=[1e-2],
                 n_comp=1,
-                categorical_kernel=HOMO_HSPHERE_KERNEL,
+                categorical_kernel=MixIntKernelType.HOMO_HSPHERE,
                 cat_kernel_comps=[3],
                 corr="squar_exp",
             ),
@@ -1025,7 +1023,7 @@ class TestMixedInteger(unittest.TestCase):
                 xspecs=xspecs,
                 theta0=[1e-2],
                 n_comp=1,
-                categorical_kernel=EXP_HOMO_HSPHERE_KERNEL,
+                categorical_kernel=MixIntKernelType.EXP_HOMO_HSPHERE,
                 cat_kernel_comps=[3, 2],
                 corr="squar_exp",
             ),
@@ -1056,7 +1054,7 @@ class TestMixedInteger(unittest.TestCase):
         mixint = MixedIntegerContext(xspecs=xspecs)
 
         sm = mixint.build_kriging_model(
-            KRG(categorical_kernel=GOWER_KERNEL, print_prediction=False)
+            KRG(categorical_kernel=MixIntKernelType.GOWER, print_prediction=False)
         )
         sampling = mixint.build_sampling_method(LHS, criterion="m")
 
@@ -1080,12 +1078,7 @@ class TestMixedInteger(unittest.TestCase):
         import numpy as np
         import matplotlib.pyplot as plt
 
-        from smt.surrogate_models import (
-            KRG,
-            XType,
-            XSpecs,
-            GOWER_KERNEL,
-        )
+        from smt.surrogate_models import KRG, XType, XSpecs, MixIntKernelType
         from smt.applications.mixed_integer import MixedIntegerKrigingModel
 
         xt1 = np.array([[0, 0.0], [0, 2.0], [0, 4.0]])
@@ -1106,7 +1099,7 @@ class TestMixedInteger(unittest.TestCase):
         sm = MixedIntegerKrigingModel(
             surrogate=KRG(
                 xspecs=xspecs,
-                categorical_kernel=GOWER_KERNEL,
+                categorical_kernel=MixIntKernelType.GOWER,
                 theta0=[1e-1],
                 corr="squar_exp",
                 n_start=20,
@@ -1204,12 +1197,7 @@ class TestMixedInteger(unittest.TestCase):
         import numpy as np
         import matplotlib.pyplot as plt
 
-        from smt.surrogate_models import (
-            KRG,
-            XType,
-            XSpecs,
-            EXP_HOMO_HSPHERE_KERNEL,
-        )
+        from smt.surrogate_models import KRG, XType, XSpecs, MixIntKernelType
         from smt.applications.mixed_integer import MixedIntegerKrigingModel
 
         xt1 = np.array([[0, 0.0], [0, 2.0], [0, 4.0]])
@@ -1233,7 +1221,7 @@ class TestMixedInteger(unittest.TestCase):
                 theta0=[1e-1],
                 corr="squar_exp",
                 n_start=20,
-                categorical_kernel=EXP_HOMO_HSPHERE_KERNEL,
+                categorical_kernel=MixIntKernelType.EXP_HOMO_HSPHERE,
             ),
         )
         sm.set_training_values(xt, yt)
@@ -1328,12 +1316,7 @@ class TestMixedInteger(unittest.TestCase):
         import numpy as np
         import matplotlib.pyplot as plt
 
-        from smt.surrogate_models import (
-            KRG,
-            XType,
-            XSpecs,
-            HOMO_HSPHERE_KERNEL,
-        )
+        from smt.surrogate_models import KRG, XType, XSpecs, MixIntKernelType
         from smt.applications.mixed_integer import MixedIntegerKrigingModel
 
         xt1 = np.array([[0, 0.0], [0, 2.0], [0, 4.0]])
@@ -1354,7 +1337,7 @@ class TestMixedInteger(unittest.TestCase):
         sm = MixedIntegerKrigingModel(
             surrogate=KRG(
                 xspecs=xspecs,
-                categorical_kernel=HOMO_HSPHERE_KERNEL,
+                categorical_kernel=MixIntKernelType.HOMO_HSPHERE,
                 theta0=[1e-1],
                 corr="squar_exp",
                 n_start=20,

--- a/smt/surrogate_models/__init__.py
+++ b/smt/surrogate_models/__init__.py
@@ -14,11 +14,7 @@ from .krg_based import (
     EXP_HOMO_HSPHERE_KERNEL,
 )
 from smt.utils.mixed_integer import XType
-from smt.utils.kriging import (
-    NEUTRAL_ROLE,
-    META_ROLE,
-    DECREED_ROLE,
-)
+from smt.utils.kriging import XRole
 
 from smt.utils.kriging import XSpecs
 

--- a/smt/surrogate_models/__init__.py
+++ b/smt/surrogate_models/__init__.py
@@ -7,12 +7,7 @@ from .kplsk import KPLSK
 from .genn import GENN
 from .mgp import MGP
 
-from .krg_based import (
-    CONT_RELAX_KERNEL,
-    GOWER_KERNEL,
-    HOMO_HSPHERE_KERNEL,
-    EXP_HOMO_HSPHERE_KERNEL,
-)
+from .krg_based import MixIntKernelType
 from smt.utils.mixed_integer import XType
 from smt.utils.kriging import XRole
 

--- a/smt/surrogate_models/__init__.py
+++ b/smt/surrogate_models/__init__.py
@@ -13,11 +13,7 @@ from .krg_based import (
     HOMO_HSPHERE_KERNEL,
     EXP_HOMO_HSPHERE_KERNEL,
 )
-from smt.utils.mixed_integer import (
-    FLOAT_TYPE,
-    ORD_TYPE,
-    ENUM_TYPE,
-)
+from smt.utils.mixed_integer import XType
 from smt.utils.kriging import (
     NEUTRAL_ROLE,
     META_ROLE,

--- a/smt/surrogate_models/krg_based.py
+++ b/smt/surrogate_models/krg_based.py
@@ -4,6 +4,7 @@ Some functions are copied from gaussian_process submodule (Scikit-learn 0.14)
 This package is distributed under New BSD license.
 """
 import numpy as np
+from enum import Enum
 from scipy import linalg, optimize
 from copy import deepcopy
 import warnings
@@ -34,11 +35,9 @@ from scipy.stats import multivariate_normal as m_norm
 from smt.sampling_methods import LHS
 from smt.utils.mixed_integer import unfold_with_enum_mask
 
-# TODO: Create hyperclass Kernels and a class for each kernel
-EXP_HOMO_HSPHERE_KERNEL = "exponential_homoscedastic_matrix_kernel"
-HOMO_HSPHERE_KERNEL = "homoscedastic_matrix_kernel"
-CONT_RELAX_KERNEL = "continuous_relaxation_matrix_kernel"
-GOWER_KERNEL = "gower_matrix_kernel"
+MixIntKernelType = Enum(
+    "MixIntKernelType", ["EXP_HOMO_HSPHERE", "HOMO_HSPHERE", "CONT_RELAX", "GOWER"]
+)
 
 
 class KrgBased(SurrogateModel):
@@ -82,10 +81,10 @@ class KrgBased(SurrogateModel):
             "categorical_kernel",
             None,
             values=[
-                CONT_RELAX_KERNEL,
-                GOWER_KERNEL,
-                EXP_HOMO_HSPHERE_KERNEL,
-                HOMO_HSPHERE_KERNEL,
+                MixIntKernelType.CONT_RELAX,
+                MixIntKernelType.GOWER,
+                MixIntKernelType.EXP_HOMO_HSPHERE,
+                MixIntKernelType.HOMO_HSPHERE,
             ],
             desc="The kernel to use for categorical inputs. Only for non continuous Kriging",
         )
@@ -334,7 +333,10 @@ class KrgBased(SurrogateModel):
         n_theta_cont = 0
         for feat in cat_features:
             if feat:
-                if cat_kernel in [EXP_HOMO_HSPHERE_KERNEL, HOMO_HSPHERE_KERNEL]:
+                if cat_kernel in [
+                    MixIntKernelType.EXP_HOMO_HSPHERE,
+                    MixIntKernelType.HOMO_HSPHERE,
+                ]:
                     theta_cont_features[
                         j : j + int(nlevels[i] * (nlevels[i] - 1) / 2)
                     ] = False
@@ -344,7 +346,10 @@ class KrgBased(SurrogateModel):
                     j += int(nlevels[i] * (nlevels[i] - 1) / 2)
                 i += 1
             else:
-                if cat_kernel in [EXP_HOMO_HSPHERE_KERNEL, HOMO_HSPHERE_KERNEL]:
+                if cat_kernel in [
+                    MixIntKernelType.EXP_HOMO_HSPHERE,
+                    MixIntKernelType.HOMO_HSPHERE,
+                ]:
                     if n_theta_cont < ncomp:
                         theta_cont_features[j] = True
                         j += 1
@@ -353,13 +358,13 @@ class KrgBased(SurrogateModel):
         X = self.training_points[None][0][0]
         y = self.training_points[None][0][1]
 
-        if cat_kernel == CONT_RELAX_KERNEL:
+        if cat_kernel == MixIntKernelType.CONT_RELAX:
             from smt.applications.mixed_integer import unfold_with_enum_mask
 
             X_pls_space = unfold_with_enum_mask(xtypes, X)
             nx = len(theta)
 
-        elif cat_kernel == GOWER_KERNEL:
+        elif cat_kernel == MixIntKernelType.GOWER:
             X_pls_space = np.copy(X)
         else:
             X_pls_space, _ = compute_X_cont(X, xtypes)
@@ -369,7 +374,10 @@ class KrgBased(SurrogateModel):
             if self.pls_coeff_cont == []:
                 X, y = self._compute_pls(X_pls_space.copy(), y.copy())
                 self.pls_coeff_cont = self.coeff_pls
-            if cat_kernel == CONT_RELAX_KERNEL or cat_kernel == GOWER_KERNEL:
+            if (
+                cat_kernel == MixIntKernelType.CONT_RELAX
+                or cat_kernel == MixIntKernelType.GOWER
+            ):
                 d = componentwise_distance_PLS(
                     dx,
                     corr,
@@ -397,10 +405,13 @@ class KrgBased(SurrogateModel):
                 theta=None,
                 return_derivative=False,
             )
-            if cat_kernel != CONT_RELAX_KERNEL:
+            if cat_kernel != MixIntKernelType.CONT_RELAX:
                 d_cont = d[:, np.logical_not(cat_features)]
 
-        if cat_kernel == CONT_RELAX_KERNEL or cat_kernel == GOWER_KERNEL:
+        if (
+            cat_kernel == MixIntKernelType.CONT_RELAX
+            or cat_kernel == MixIntKernelType.GOWER
+        ):
             r = _correlation_types[corr](theta, d)
             return r
 
@@ -415,9 +426,9 @@ class KrgBased(SurrogateModel):
             self.coeff_pls_cat = []
         for i in range(len(nlevels)):
             theta_cat = theta[theta_cat_features[:, i]]
-            if cat_kernel == EXP_HOMO_HSPHERE_KERNEL:
+            if cat_kernel == MixIntKernelType.EXP_HOMO_HSPHERE:
                 theta_cat = theta_cat * (0.5 * np.pi / theta_bounds[1])
-            elif cat_kernel == HOMO_HSPHERE_KERNEL:
+            elif cat_kernel == MixIntKernelType.HOMO_HSPHERE:
                 theta_cat = theta_cat * (2.0 * np.pi / theta_bounds[1])
             Theta_mat = np.zeros((nlevels[i], nlevels[i]))
             L = np.zeros((nlevels[i], nlevels[i]))
@@ -452,7 +463,7 @@ class KrgBased(SurrogateModel):
 
             T = np.dot(L, L.T)
 
-            if cat_kernel == EXP_HOMO_HSPHERE_KERNEL:
+            if cat_kernel == MixIntKernelType.EXP_HOMO_HSPHERE:
                 T = (T - 1) * theta_bounds[1] / 2
                 T = np.exp(2 * T)
             k = (1 + np.exp(-theta_bounds[1])) / np.exp(-theta_bounds[0])
@@ -501,7 +512,10 @@ class KrgBased(SurrogateModel):
                 if indi == indj:
                     r_cat[k] = 1.0
                 else:
-                    if cat_kernel in [EXP_HOMO_HSPHERE_KERNEL, HOMO_HSPHERE_KERNEL]:
+                    if cat_kernel in [
+                        MixIntKernelType.EXP_HOMO_HSPHERE,
+                        MixIntKernelType.HOMO_HSPHERE,
+                    ]:
                         if cat_kernel_comps is not None:
                             Theta_i_red = np.zeros(
                                 int((nlevels[i] - 1) * nlevels[i] / 2)
@@ -584,7 +598,7 @@ class KrgBased(SurrogateModel):
             noise = tmp_var[self.D.shape[1] :]
         if self.options["categorical_kernel"] is not None:
             dx = self.D
-            if self.options["categorical_kernel"] == CONT_RELAX_KERNEL:
+            if self.options["categorical_kernel"] == MixIntKernelType.CONT_RELAX:
                 from smt.applications.mixed_integer import unfold_with_enum_mask
 
                 X2 = unfold_with_enum_mask(
@@ -1028,7 +1042,7 @@ class KrgBased(SurrogateModel):
                     X=x, ij=ij, xtypes=self.options["xspecs"].types, y=self.X_train
                 )
                 self.ij = ij
-                if self.options["categorical_kernel"] == CONT_RELAX_KERNEL:
+                if self.options["categorical_kernel"] == MixIntKernelType.CONT_RELAX:
                     Xpred = unfold_with_enum_mask(self.options["xspecs"].types, x)
                     Xpred_norma = (Xpred - self.X2_offset) / self.X2_scale
                     # Get pairwise componentwise L1-distances to the input training set
@@ -1159,7 +1173,7 @@ class KrgBased(SurrogateModel):
                     X=x, ij=ij, xtypes=self.options["xspecs"].types, y=self.X_train
                 )
                 self.ij = ij
-                if self.options["categorical_kernel"] == CONT_RELAX_KERNEL:
+                if self.options["categorical_kernel"] == MixIntKernelType.CONT_RELAX:
                     from smt.applications.mixed_integer import unfold_with_enum_mask
 
                     Xpred = unfold_with_enum_mask(self.options["xspecs"].types, x)
@@ -1603,7 +1617,10 @@ class KrgBased(SurrogateModel):
                 )
             if (
                 self.options["categorical_kernel"]
-                not in [EXP_HOMO_HSPHERE_KERNEL, HOMO_HSPHERE_KERNEL]
+                not in [
+                    MixIntKernelType.EXP_HOMO_HSPHERE,
+                    MixIntKernelType.HOMO_HSPHERE,
+                ]
                 and self.name == "KPLS"
             ):
                 if self.options["cat_kernel_comps"] is not None:
@@ -1617,9 +1634,9 @@ class KrgBased(SurrogateModel):
             else None
         )
         if self.options["categorical_kernel"] in [
-            EXP_HOMO_HSPHERE_KERNEL,
-            HOMO_HSPHERE_KERNEL,
-            CONT_RELAX_KERNEL,
+            MixIntKernelType.EXP_HOMO_HSPHERE,
+            MixIntKernelType.HOMO_HSPHERE,
+            MixIntKernelType.CONT_RELAX,
         ]:
             n_comp = self.options["n_comp"] if "n_comp" in self.options else None
             n_param = compute_n_param(
@@ -1636,9 +1653,9 @@ class KrgBased(SurrogateModel):
         if len(self.options["theta0"]) != d and self.options[
             "categorical_kernel"
         ] not in [
-            EXP_HOMO_HSPHERE_KERNEL,
-            CONT_RELAX_KERNEL,
-            HOMO_HSPHERE_KERNEL,
+            MixIntKernelType.EXP_HOMO_HSPHERE,
+            MixIntKernelType.CONT_RELAX,
+            MixIntKernelType.HOMO_HSPHERE,
         ]:
             if len(self.options["theta0"]) == 1:
                 self.options["theta0"] *= np.ones(d)
@@ -1715,7 +1732,7 @@ def compute_n_param(xtypes, cat_kernel, nx, d, n_comp, mat_dim):
     n_param = nx
     if n_comp is not None:
         n_param = d
-        if cat_kernel == CONT_RELAX_KERNEL:
+        if cat_kernel == MixIntKernelType.CONT_RELAX:
             return n_param
         if mat_dim is not None:
             return int(np.sum([l * (l - 1) / 2 for l in mat_dim]) + n_param)
@@ -1724,8 +1741,11 @@ def compute_n_param(xtypes, cat_kernel, nx, d, n_comp, mat_dim):
         if isinstance(xtyp, tuple):
             if nx == d:
                 n_param -= 1
-            if cat_kernel in [EXP_HOMO_HSPHERE_KERNEL, HOMO_HSPHERE_KERNEL]:
+            if cat_kernel in [
+                MixIntKernelType.EXP_HOMO_HSPHERE,
+                MixIntKernelType.HOMO_HSPHERE,
+            ]:
                 n_param += int(xtyp[1] * (xtyp[1] - 1) / 2)
-            if cat_kernel == CONT_RELAX_KERNEL:
+            if cat_kernel == MixIntKernelType.CONT_RELAX:
                 n_param += int(xtyp[1])
     return n_param

--- a/smt/surrogate_models/tests/test_surrogate_model_examples.py
+++ b/smt/surrogate_models/tests/test_surrogate_model_examples.py
@@ -270,7 +270,7 @@ class Test(unittest.TestCase):
         plt.show()
 
     def test_mixed_gower_krg(self):
-        from smt.surrogate_models import XType, GOWER_KERNEL, KRG
+        from smt.surrogate_models import XType, MixIntKernelType, KRG
         from smt.applications.mixed_integer import (
             MixedIntegerKrigingModel,
         )
@@ -287,7 +287,7 @@ class Test(unittest.TestCase):
         # Surrogate
         sm = MixedIntegerKrigingModel(
             surrogate=KRG(
-                xspecs=xspecs, theta0=[1e-2], categorical_kernel=GOWER_KERNEL
+                xspecs=xspecs, theta0=[1e-2], categorical_kernel=MixIntKernelType.GOWER
             ),
         )
         sm.set_training_values(xt, yt)
@@ -306,7 +306,6 @@ class Test(unittest.TestCase):
 
     def test_kpls_auto(self):
         import numpy as np
-        import matplotlib.pyplot as plt
         from smt.surrogate_models import KPLS
         from smt.problems import TensorProduct
         from smt.sampling_methods import LHS

--- a/smt/surrogate_models/tests/test_surrogate_model_examples.py
+++ b/smt/surrogate_models/tests/test_surrogate_model_examples.py
@@ -228,7 +228,7 @@ class Test(unittest.TestCase):
         import numpy as np
         import matplotlib.pyplot as plt
 
-        from smt.surrogate_models import KRG, ORD_TYPE
+        from smt.surrogate_models import KRG, XType
         from smt.applications.mixed_integer import MixedIntegerKrigingModel
         from smt.utils.kriging import XSpecs
 
@@ -240,7 +240,7 @@ class Test(unittest.TestCase):
         # ORD means x2 integer
         # (ENUM, 3) means x3, x4 & x5 are 3 levels of the same categorical variable
         # (ENUM, 2) means x6 & x7 are 2 levels of the same categorical variable
-        xspecs = XSpecs(xtypes=[ORD_TYPE], xlimits=[[0, 4]])
+        xspecs = XSpecs(xtypes=[XType.ORD], xlimits=[[0, 4]])
         sm = MixedIntegerKrigingModel(surrogate=KRG(xspecs=xspecs, theta0=[1e-2]))
         sm.set_training_values(xt, yt)
         sm.train()
@@ -270,7 +270,7 @@ class Test(unittest.TestCase):
         plt.show()
 
     def test_mixed_gower_krg(self):
-        from smt.surrogate_models import ENUM_TYPE, GOWER_KERNEL, KRG
+        from smt.surrogate_models import XType, GOWER_KERNEL, KRG
         from smt.applications.mixed_integer import (
             MixedIntegerKrigingModel,
         )
@@ -281,7 +281,7 @@ class Test(unittest.TestCase):
         xt = np.array([0, 3, 4])
         yt = np.array([0.0, 1.0, 1.5])
         xspecs = XSpecs(
-            xtypes=[(ENUM_TYPE, 5)], xlimits=[["0.0", "1.0", " 2.0", "3.0", "4.0"]]
+            xtypes=[(XType.ENUM, 5)], xlimits=[["0.0", "1.0", " 2.0", "3.0", "4.0"]]
         )
 
         # Surrogate

--- a/smt/utils/kriging.py
+++ b/smt/utils/kriging.py
@@ -365,7 +365,7 @@ def gower_componentwise_distances(X, xspecs, y=None):
     maxmetanum = 1
     if np.shape(lim)[0] > 0:
         for k, i in enumerate(lim):
-            if xspecs.roles[k] != "meta_role":
+            if xspecs.roles[k] != XRole.META:
                 lb[k] = i[0]
                 ub[k] = i[-1]
             else:
@@ -460,8 +460,8 @@ def apply_the_algebraic_distance_to_the_decreed_variable(
 ):
     nx_samples, n_features = X_num.shape
     ny_samples, n_features = Y_num.shape
-    decreed_features = np.array([(xrole == "decreed_role") for xrole in xspecs.roles])
-    meta_features = np.array([(xrole == "meta_role") for xrole in xspecs.roles])
+    decreed_features = np.array([(xrole == XRole.DECREED) for xrole in xspecs.roles])
+    meta_features = np.array([(xrole == XRole.META) for xrole in xspecs.roles])
     decreed_num_features = decreed_features[np.logical_not(cat_features)]
     meta_num_features = meta_features[np.logical_not(cat_features)]
     meta_cat_features = meta_features[cat_features]

--- a/smt/utils/kriging.py
+++ b/smt/utils/kriging.py
@@ -5,6 +5,7 @@ This package is distributed under New BSD license.
 """
 
 import numpy as np
+from enum import Enum
 from copy import deepcopy
 
 from sklearn.cross_decomposition import PLSRegression as pls
@@ -14,9 +15,7 @@ from sklearn.metrics.pairwise import check_pairwise_arrays
 from smt.utils.mixed_integer import XType
 
 ## This define the variables roles for hierarchical Kriging models
-NEUTRAL_ROLE = "neutral_role"
-META_ROLE = "meta_role"
-DECREED_ROLE = "decreed_role"
+XRole = Enum("XType", ["NEUTRAL", "META", "DECREED"])
 
 
 class XSpecs:
@@ -46,7 +45,7 @@ class XSpecs:
         if (
             xroles is None and xlimits is not None
         ):  # when xroles is not specified default to neutral
-            self._xroles = [NEUTRAL_ROLE] * len(xlimits)
+            self._xroles = [XRole.NEUTRAL] * len(xlimits)
         else:
             self._xroles = xroles
         self._check_consistency()
@@ -421,7 +420,7 @@ def compute_D_cat(X_cat, Y_cat, y):
 
 
 def compute_D_num(X_num, Y_num, y, xspecs, X_cat, Y_cat, cat_features, maxmetanum):
-    active_roles = len(xspecs.limits) * [NEUTRAL_ROLE] != xspecs.roles
+    active_roles = len(xspecs.limits) * [XRole.NEUTRAL] != xspecs.roles
     nx_samples, n_features = X_num.shape
     ny_samples, n_features = Y_num.shape
     n_nonzero_cross_dist = nx_samples * ny_samples

--- a/smt/utils/kriging.py
+++ b/smt/utils/kriging.py
@@ -11,11 +11,7 @@ from sklearn.cross_decomposition import PLSRegression as pls
 
 from pyDOE2 import bbdesign
 from sklearn.metrics.pairwise import check_pairwise_arrays
-from smt.utils.mixed_integer import (
-    ENUM_TYPE,
-    ORD_TYPE,
-    FLOAT_TYPE,
-)
+from smt.utils.mixed_integer import XType
 
 ## This define the variables roles for hierarchical Kriging models
 NEUTRAL_ROLE = "neutral_role"
@@ -44,7 +40,7 @@ class XSpecs:
         if (
             xtypes is None and xlimits is not None
         ):  # when xtypes is not specified default to float
-            self._xtypes = [FLOAT_TYPE] * len(xlimits)
+            self._xtypes = [XType.FLOAT] * len(xlimits)
         else:
             self._xtypes = xtypes
         if (
@@ -117,7 +113,7 @@ class XSpecs:
 
         for i, xtyp in enumerate(self._xtypes):
             if (not isinstance(xtyp, tuple)) and len(self._xlimits[i]) != 2:
-                if xtyp == ORD_TYPE and isinstance(self._xlimits[i][0], str):
+                if xtyp == XType.ORD and isinstance(self._xlimits[i][0], str):
                     listint = list(map(float, self._xlimits[i]))
                     sortedlistint = sorted(listint)
                     if not np.array_equal(sortedlistint, listint):
@@ -129,9 +125,9 @@ class XSpecs:
                         f"Bad x limits ({self._xlimits[i]}) for variable type {xtyp} (index={i})"
                     )
             if (
-                xtyp != FLOAT_TYPE
-                and xtyp != ORD_TYPE
-                and (not isinstance(xtyp, tuple) or xtyp[0] != ENUM_TYPE)
+                xtyp != XType.FLOAT
+                and xtyp != XType.ORD
+                and (not isinstance(xtyp, tuple) or xtyp[0] != XType.ENUM)
             ):
                 raise ValueError(f"Bad type specification {xtyp}")
 
@@ -298,7 +294,7 @@ def compute_X_cont(x, xtypes):
     if xtypes is None:
         return x, None
     cat_features = [
-        not (xtype == "float_type" or xtype == "ord_type") for xtype in xtypes
+        not (xtype == XType.FLOAT or xtype == XType.ORD) for xtype in xtypes
     ]
     return x[:, np.logical_not(cat_features)], cat_features
 

--- a/smt/utils/test/test_kriging_utils.py
+++ b/smt/utils/test/test_kriging_utils.py
@@ -6,15 +6,8 @@ Author: Paul Saves
 import unittest
 import numpy as np
 from smt.utils.kriging import XSpecs
-from smt.utils.mixed_integer import (
-    XType,
-    unfold_xlimits_with_continuous_limits,
-)
-from smt.utils.kriging import (
-    NEUTRAL_ROLE,
-    DECREED_ROLE,
-    META_ROLE,
-)
+from smt.utils.mixed_integer import XType
+from smt.utils.kriging import XRole
 
 
 class Test(unittest.TestCase):
@@ -34,7 +27,7 @@ class Test(unittest.TestCase):
     def test_xspecs_check_consistency(self):
         xtypes = [XType.FLOAT, (XType.ENUM, 3)]
         xlimits = [[-10, 10], ["blue", "red", "green"]]
-        xroles = [[DECREED_ROLE, META_ROLE, DECREED_ROLE]]  # Bad dimension
+        xroles = [[XRole.DECREED, XRole.META, XRole.DECREED]]  # Bad dimension
         with self.assertRaises(ValueError):
             XSpecs(xtypes=xtypes, xlimits=xlimits, xroles=xroles)
 

--- a/smt/utils/test/test_kriging_utils.py
+++ b/smt/utils/test/test_kriging_utils.py
@@ -7,9 +7,7 @@ import unittest
 import numpy as np
 from smt.utils.kriging import XSpecs
 from smt.utils.mixed_integer import (
-    ORD_TYPE,
-    FLOAT_TYPE,
-    ENUM_TYPE,
+    XType,
     unfold_xlimits_with_continuous_limits,
 )
 from smt.utils.kriging import (
@@ -31,21 +29,21 @@ class Test(unittest.TestCase):
 
         # ok default to float
         xspecs = XSpecs(xlimits=[[0, 1]])
-        self.assertEqual([FLOAT_TYPE], xspecs.types)
+        self.assertEqual([XType.FLOAT], xspecs.types)
 
     def test_xspecs_check_consistency(self):
-        xtypes = [FLOAT_TYPE, (ENUM_TYPE, 3)]
+        xtypes = [XType.FLOAT, (XType.ENUM, 3)]
         xlimits = [[-10, 10], ["blue", "red", "green"]]
         xroles = [[DECREED_ROLE, META_ROLE, DECREED_ROLE]]  # Bad dimension
         with self.assertRaises(ValueError):
             XSpecs(xtypes=xtypes, xlimits=xlimits, xroles=xroles)
 
-        xtypes = [FLOAT_TYPE, (ENUM_TYPE, 3), ORD_TYPE]
+        xtypes = [XType.FLOAT, (XType.ENUM, 3), XType.ORD]
         xlimits = [[-10, 10], ["blue", "red"], [-10, 10]]  # Bad enum
         with self.assertRaises(ValueError):
             XSpecs(xtypes=xtypes, xlimits=xlimits)
 
-        xtypes = [FLOAT_TYPE, (ENUM_TYPE, 2), (ENUM_TYPE, 3), ORD_TYPE]
+        xtypes = [XType.FLOAT, (XType.ENUM, 2), (XType.ENUM, 3), XType.ORD]
         xlimits = np.array(
             [[-5, 5], ["blue", "red"], ["short", "medium", "long"], ["0", "4", "3"]],
             dtype="object",


### PR DESCRIPTION
This PR replaces 

- [x] `*_TYPE` constants by `XType` enum equivalent,
- [x] `*_ROLE` constants by `XRole` enum equivalent,
- [x] `*_KERNEL` constants by `MixIntKernelType` enum equivalent,