### PR TITLE
Implements the Arc-kernel for hierarchical variables

### DIFF
--- a/smt/applications/tests/test_mixed_integer.py
+++ b/smt/applications/tests/test_mixed_integer.py
@@ -36,6 +36,7 @@ from smt.surrogate_models import (
     XType,
     XRole,
     MixIntKernelType,
+    MixHrcKernelType,
 )
 
 
@@ -558,6 +559,7 @@ class TestMixedInteger(unittest.TestCase):
             surrogate=KRG(
                 xspecs=xspecs,
                 categorical_kernel=MixIntKernelType.HOMO_HSPHERE,
+                hierarchical_kernel=MixHrcKernelType.ALG_KERNEL,
                 theta0=[1e-2],
                 corr="abs_exp",
                 n_start=5,
@@ -666,6 +668,7 @@ class TestMixedInteger(unittest.TestCase):
             XType,
             XRole,
             MixIntKernelType,
+            MixHrcKernelType,
         )
 
         def f_hv(X):
@@ -827,6 +830,7 @@ class TestMixedInteger(unittest.TestCase):
             surrogate=KRG(
                 xspecs=xspecs,
                 categorical_kernel=MixIntKernelType.HOMO_HSPHERE,
+                hierarchical_kernel=MixHrcKernelType.ALG_KERNEL,
                 theta0=[1e-2],
                 corr="abs_exp",
                 n_start=5,
@@ -940,6 +944,7 @@ class TestMixedInteger(unittest.TestCase):
             surrogate=KRG(
                 xspecs=xspecs,
                 categorical_kernel=MixIntKernelType.HOMO_HSPHERE,
+                hierarchical_kernel=MixHrcKernelType.ALG_KERNEL,
                 theta0=[1e-2],
                 corr="abs_exp",
                 n_start=5,

--- a/smt/problems/tests/test_problem_examples.py
+++ b/smt/problems/tests/test_problem_examples.py
@@ -75,7 +75,7 @@ class Test(unittest.TestCase):
         )
         xdoe = sampling(n_doe)
         y = problem(xdoe)
-        
+
         plt.scatter(xdoe[:, 0], y)
         plt.xlabel("x")
         plt.ylabel("y")
@@ -140,7 +140,7 @@ class Test(unittest.TestCase):
         )
         xdoe = sampling(n_doe)
         y = problem(xdoe)
-        
+
         plt.scatter(xdoe[:, 0], y)
         plt.xlabel("x")
         plt.ylabel("y")

--- a/smt/surrogate_models/__init__.py
+++ b/smt/surrogate_models/__init__.py
@@ -8,6 +8,7 @@ from .genn import GENN
 from .mgp import MGP
 
 from .krg_based import MixIntKernelType
+from smt.utils.kriging import MixHrcKernelType
 from smt.utils.mixed_integer import XType
 from smt.utils.kriging import XRole
 

--- a/smt/surrogate_models/krg_based.py
+++ b/smt/surrogate_models/krg_based.py
@@ -29,6 +29,7 @@ from smt.utils.kriging import (
     compute_X_cross,
     cross_levels_homo_space,
     XSpecs,
+    MixHrcKernelType,
 )
 from smt.utils.misc import standardization
 from scipy.stats import multivariate_normal as m_norm
@@ -87,6 +88,15 @@ class KrgBased(SurrogateModel):
                 MixIntKernelType.HOMO_HSPHERE,
             ],
             desc="The kernel to use for categorical inputs. Only for non continuous Kriging",
+        )
+        declare(
+            "hierarchical_kernel",
+            MixHrcKernelType.ALG_KERNEL,
+            values=[
+                MixHrcKernelType.ALG_KERNEL,
+                MixHrcKernelType.ARC_KERNEL,
+            ],
+            desc="The kernel to use for mixed hierarchical inputs. Only for non continuous Kriging",
         )
         declare(
             "nugget",
@@ -177,7 +187,9 @@ class KrgBased(SurrogateModel):
 
         if self.options["categorical_kernel"] is not None:
             D, self.ij, X = gower_componentwise_distances(
-                X=X, xspecs=self.options["xspecs"]
+                X=X,
+                xspecs=self.options["xspecs"],
+                hierarchical_kernel=self.options["hierarchical_kernel"],
             )
             self.Lij, self.n_levels = cross_levels(
                 X=self.X_train, ij=self.ij, xtypes=self.options["xspecs"].types
@@ -1026,6 +1038,7 @@ class KrgBased(SurrogateModel):
             dx = gower_componentwise_distances(
                 x,
                 xspecs=self.options["xspecs"],
+                hierarchical_kernel=self.options["hierarchical_kernel"],
                 y=np.copy(self.X_train),
             )
 
@@ -1157,6 +1170,7 @@ class KrgBased(SurrogateModel):
             dx = gower_componentwise_distances(
                 x,
                 xspecs=self.options["xspecs"],
+                hierarchical_kernel=self.options["hierarchical_kernel"],
                 y=np.copy(self.X_train),
             )
             d = componentwise_distance(

--- a/smt/utils/kriging.py
+++ b/smt/utils/kriging.py
@@ -363,14 +363,14 @@ def gower_componentwise_distances(X, xspecs, hierarchical_kernel, y=None):
     lim = np.array(xspecs.limits, dtype=object)[np.logical_not(cat_features)]
     lb = np.zeros(np.shape(lim)[0])
     ub = np.ones(np.shape(lim)[0])
-    maxmetanum = 1
+    max_meta_num = 1
     if np.shape(lim)[0] > 0:
         for k, i in enumerate(lim):
             if xspecs.roles[k] != XRole.META:
                 lb[k] = i[0]
                 ub[k] = i[-1]
             else:
-                maxmetanum = i[-1]
+                max_meta_num = i[-1]
         Z_offset = lb
         Z_max = ub
         Z_scale = Z_max - Z_offset
@@ -391,7 +391,7 @@ def gower_componentwise_distances(X, xspecs, hierarchical_kernel, y=None):
         X_cat,
         Y_cat,
         cat_features,
-        maxmetanum,
+        max_meta_num,
         hierarchical_kernel,
     )
     D = np.concatenate((D_cat, D_num), axis=1) * 0
@@ -429,7 +429,15 @@ def compute_D_cat(X_cat, Y_cat, y):
 
 
 def compute_D_num(
-    X_num, Y_num, y, xspecs, X_cat, Y_cat, cat_features, maxmetanum, hierarchical_kernel
+    X_num,
+    Y_num,
+    y,
+    xspecs,
+    X_cat,
+    Y_cat,
+    cat_features,
+    max_meta_num,
+    hierarchical_kernel,
 ):
     active_roles = len(xspecs.limits) * [XRole.NEUTRAL] != xspecs.roles
     nx_samples, n_features = X_num.shape
@@ -464,7 +472,7 @@ def compute_D_num(
             X_num,
             Y_num,
             y,
-            maxmetanum,
+            max_meta_num,
             cat_features,
             X_cat,
             Y_cat,
@@ -480,7 +488,7 @@ def apply_the_algebraic_distance_to_the_decreed_variable(
     X_num,
     Y_num,
     y,
-    maxmetanum,
+    max_meta_num,
     cat_features,
     X_cat,
     Y_cat,
@@ -532,7 +540,7 @@ def apply_the_algebraic_distance_to_the_decreed_variable(
                         )
                     )
                 )
-            abs_delta[meta_num_features] = abs_delta[meta_num_features] / maxmetanum
+            abs_delta[meta_num_features] = abs_delta[meta_num_features] / max_meta_num
 
             if np.max(meta_num_features):
                 # This is the meta variable index


### PR DESCRIPTION
Implement Hierarchical kernels with 2 options (ALG and ARC kernels)
`              

             declare(
            "hierarchical_kernel",
            MixHrcKernelType.ALG_KERNEL,
            values=[
                MixHrcKernelType.ALG_KERNEL,
                MixHrcKernelType.ARC_KERNEL,
            ],
            desc="The kernel to use for mixed hierarchical inputs. Only for non continuous Kriging",
        )


`