### PR TITLE
CI: Test Python 3.11 on all OS, 3.10 and lower on Ubuntu

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,16 +10,17 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10']
-        exclude:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.11"]
+        include:
           - os: ubuntu-latest
-            python-version: '3.8'
-          - os: windows-latest
-            python-version: '3.10'
-          - os: macos-latest
-            python-version: '3.10'
+            python-version: "3.10"
+          - os: ubuntu-latest
+            python-version: "3.9"
+          - os: ubuntu-latest
+            python-version: "3.8"
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Updates the job matrix of the GitHub Actions test workflow to test with Python 3.11 on all operating systems. 3.8, 3.9 and 3.10 are tested with one OS, Ubuntu. This configurations keeps the number of jobs reasonable at 6, while testing all operating systems and four Python versions.

Also sets `fail-fast` to `false`, so that other runs continue if one fails.