### PR TITLE
Support value decoding for complete design vectors

### DIFF
--- a/smt/utils/design_space.py
+++ b/smt/utils/design_space.py
@@ -247,7 +247,9 @@ class BaseDesignSpace:
 
         return x_corrected, is_acting
 
-    def decode_values(self, x: np.ndarray, i_dv: int = None) -> List[Union[str, int, float, list]]:
+    def decode_values(
+        self, x: np.ndarray, i_dv: int = None
+    ) -> List[Union[str, int, float, list]]:
         """
         Return decoded values: converts ordinal and categorical back to their original values.
 
@@ -283,10 +285,15 @@ class BaseDesignSpace:
         is_1d = len(x.shape) == 1
         x_mat = np.atleast_2d(x)
         if x_mat.shape[1] != n_dv:
-            raise ValueError(f'Incorrect number of inputs, expected {n_dv} design variables, received {x_mat.shape[1]}')
+            raise ValueError(
+                f"Incorrect number of inputs, expected {n_dv} design variables, received {x_mat.shape[1]}"
+            )
 
         decoded_des_vars = [_decode_dv(x_mat[:, i], i_dv_decode=i) for i in range(n_dv)]
-        decoded_des_vectors = [[decoded_des_vars[i][ix] for i in range(n_dv)] for ix in range(x_mat.shape[0])]
+        decoded_des_vectors = [
+            [decoded_des_vars[i][ix] for i in range(n_dv)]
+            for ix in range(x_mat.shape[0])
+        ]
         return decoded_des_vectors[0] if is_1d else decoded_des_vectors
 
     def sample_valid_x(self, n: int, unfolded=False) -> Tuple[np.ndarray, np.ndarray]:

--- a/smt/utils/test/test_design_space.py
+++ b/smt/utils/test/test_design_space.py
@@ -189,13 +189,16 @@ class Test(unittest.TestCase):
         self.assertEqual(ds.decode_values(np.array([0, 1, 2]), i_dv=0), ["A", "B", "C"])
         self.assertEqual(ds.decode_values(np.array([0, 1]), i_dv=1), ["E", "F"])
 
-        self.assertEqual(ds.decode_values(x[0, :]), ['B', 'E', 0, .834])
-        self.assertEqual(ds.decode_values(x[[0], :]), [['B', 'E', 0, .834]])
-        self.assertEqual(ds.decode_values(x), [
-            ['B', 'E', 0, .834],
-            ['C', 'E', -1, .6434],
-            ['C', 'E', 0, 1.151],
-        ])
+        self.assertEqual(ds.decode_values(x[0, :]), ["B", "E", 0, 0.834])
+        self.assertEqual(ds.decode_values(x[[0], :]), [["B", "E", 0, 0.834]])
+        self.assertEqual(
+            ds.decode_values(x),
+            [
+                ["B", "E", 0, 0.834],
+                ["C", "E", -1, 0.6434],
+                ["C", "E", 0, 1.151],
+            ],
+        )
 
         x_corr, is_act_corr = ds.correct_get_acting(x)
         self.assertTrue(np.all(x_corr == x))

--- a/smt/utils/test/test_design_space.py
+++ b/smt/utils/test/test_design_space.py
@@ -189,6 +189,14 @@ class Test(unittest.TestCase):
         self.assertEqual(ds.decode_values(np.array([0, 1, 2]), i_dv=0), ["A", "B", "C"])
         self.assertEqual(ds.decode_values(np.array([0, 1]), i_dv=1), ["E", "F"])
 
+        self.assertEqual(ds.decode_values(x[0, :]), ['B', 'E', 0, .834])
+        self.assertEqual(ds.decode_values(x[[0], :]), [['B', 'E', 0, .834]])
+        self.assertEqual(ds.decode_values(x), [
+            ['B', 'E', 0, .834],
+            ['C', 'E', -1, .6434],
+            ['C', 'E', 0, 1.151],
+        ])
+
         x_corr, is_act_corr = ds.correct_get_acting(x)
         self.assertTrue(np.all(x_corr == x))
         self.assertTrue(np.all(is_act_corr == is_acting))


### PR DESCRIPTION
At the request of @NatOnera:
- Allows to pass a single design vector and decode categorical/ordinal variable values
- Allows to pass multiple design vectors (n x nx matrix) and decode multiple design vectors at once