### PR TITLE
Update deprecated setup.cfg fields

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,3 @@
 [metadata]
-description-file = README.md
-license_file = LICENSE.txt
-
+description_file = README.md
+license_files = LICENSE.txt


### PR DESCRIPTION
Two deprecation warnings were seen when installing smt 2.0: https://github.com/jbussemaker/SBArchOpt/issues/3#issue-1788362993

Fixed according to: https://setuptools.pypa.io/en/latest/userguide/declarative_config.html