### PR TITLE
Fix for expired deprecation in numpy 1.25

### DIFF
--- a/smt/applications/tests/test_ego.py
+++ b/smt/applications/tests/test_ego.py
@@ -854,7 +854,7 @@ class TestEGO(SMTestCase):
                 assert kx is None
                 response = self.super._evaluate(x, kx)
                 sens = np.hstack(
-                    self.super._evaluate(x, ki) for ki in range(x.shape[1])
+                    [self.super._evaluate(x, ki) for ki in range(x.shape[1])]
                 )
                 return np.hstack((response, sens))
 


### PR DESCRIPTION
This PR fixes error due to [expired deprecation in numpy 1.25.0](https://github.com/numpy/numpy/pull/23019)