### PR TITLE
Update pyDOE2 dependency to pyDOE3

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To cite SMT legacy: M. A. Bouhlel and J. T. Hwang and N. Bartoli and R. Lafage a
 ```
 
 # Required packages
-SMT depends on the following modules: numpy, scipy, scikit-learn, pyDOE2 and Cython. 
+SMT depends on the following modules: numpy, scipy, scikit-learn, pyDOE3 and Cython. 
 
 # Installation
 If you want to install the latest release

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -2,7 +2,7 @@ Cython
 numpy
 scipy
 scikit-learn
-pyDOE2
+pyDOE3
 numpydoc
 matplotlib
 git+https://github.com/hwangjt/sphinx_auto_embed.git  # for doc generation 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Cython
 numpy
 scipy
 scikit-learn
-pyDOE2
+pyDOE3
 numba        # JIT compiler
 matplotlib   # used in examples and tests
 pytest       # tests runner

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ metadata = dict(
     ],
     install_requires=[
         "scikit-learn",
-        "pyDOE2",
+        "pyDOE3",
         "scipy",
     ],
     extras_require={

--- a/smt/examples/multi_modal/run_genn_demo.py
+++ b/smt/examples/multi_modal/run_genn_demo.py
@@ -14,7 +14,7 @@ from smt.surrogate_models.genn import GENN, load_smt_data
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.gridspec as gridspec
-from pyDOE2 import fullfact
+from pyDOE3 import fullfact
 
 SEED = 101
 

--- a/smt/sampling_methods/lhs.py
+++ b/smt/sampling_methods/lhs.py
@@ -3,9 +3,9 @@ Author: Dr. John T. Hwang <hwangjt@umich.edu>
 
 This package is distributed under New BSD license.
 
-LHS sampling; uses the pyDOE2 package.
+LHS sampling; uses the pyDOE3 package.
 """
-from pyDOE2 import lhs
+from pyDOE3 import lhs
 from scipy.spatial.distance import pdist, cdist
 import numpy as np
 

--- a/smt/utils/kriging.py
+++ b/smt/utils/kriging.py
@@ -10,7 +10,7 @@ from copy import deepcopy
 import os
 from sklearn.cross_decomposition import PLSRegression as pls
 
-from pyDOE2 import bbdesign
+from pyDOE3 import bbdesign
 from sklearn.metrics.pairwise import check_pairwise_arrays
 from smt.utils.design_space import BaseDesignSpace, CategoricalVariable
 


### PR DESCRIPTION
pyDOE2 is not supported any more, use pyDOE3. See #470 