### PR TITLE
Fix import error when `ConfigSpace` not installed

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,8 +19,6 @@ jobs:
             python-version: "3.10"
           - os: ubuntu-latest
             python-version: "3.9"
-          - os: ubuntu-latest
-            python-version: "3.8"
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/tests_minimal.yml
+++ b/.github/workflows/tests_minimal.yml
@@ -1,0 +1,30 @@
+name: Tests Minimal
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.8"
+
+    - name: Install dependencies
+      run: |
+        pip install --upgrade pip
+        pip install numpy cython
+        pip install -e .
+
+    - name: Test with pytest
+      run: |
+        pip install pytest
+        pytest smt
+
+

--- a/.github/workflows/tests_minimal.yml
+++ b/.github/workflows/tests_minimal.yml
@@ -19,7 +19,8 @@ jobs:
     - name: Install dependencies
       run: |
         pip install --upgrade pip
-        pip install numpy cython
+        pip install numpy cython 
+        pip install matplotlib   # required by GENN atm, to be fixed
         pip install -e .
 
     - name: Test with pytest

--- a/smt/applications/tests/test_ego.py
+++ b/smt/applications/tests/test_ego.py
@@ -37,6 +37,7 @@ from smt.applications.mixed_integer import (
     MixedIntegerContext,
     MixedIntegerSamplingMethod,
 )
+import smt.utils.design_space as ds
 
 
 # This implementation only works with Python > 3.3
@@ -892,7 +893,7 @@ class TestEGO(SMTestCase):
 
         return ego, fun
 
-    def test_sampling_consistency(self):
+    def test_ego_seeding(self):
         def f_obj(X):
             """
             s01 objective
@@ -997,8 +998,12 @@ class TestEGO(SMTestCase):
             n_start=15,
         )
         x_opt, y_opt, dnk, x_data, y_data = ego.optimize(fun=f_obj)
-        self.assertAlmostEqual(np.sum(y_data), 2.7639515433083854, delta=1e-4)
-        self.assertAlmostEqual(np.sum(x_data), 32.11001423996299, delta=1e-4)
+        if ds.HAS_CONFIG_SPACE:  # results differs wrt config_space impl
+            self.assertAlmostEqual(np.sum(y_data), 2.7639515433083854, delta=1e-4)
+            self.assertAlmostEqual(np.sum(x_data), 32.11001423996299, delta=1e-4)
+        else:
+            self.assertAlmostEqual(np.sum(y_data), 2.03831406306514, delta=1e-4)
+            self.assertAlmostEqual(np.sum(x_data), 33.56885202767958, delta=1e-4)
 
     def test_ego_gek(self):
         ego, fun = self.initialize_ego_gek()

--- a/smt/applications/tests/test_mixed_integer.py
+++ b/smt/applications/tests/test_mixed_integer.py
@@ -23,6 +23,8 @@ from smt.utils.design_space import (
     OrdinalVariable,
     CategoricalVariable,
 )
+import smt.utils.design_space as ds
+
 from smt.sampling_methods import LHS
 from smt.surrogate_models import (
     KRG,
@@ -300,7 +302,8 @@ class TestMixedInteger(unittest.TestCase):
         self.run_mixed_integer_context_example()
         self.run_hierarchical_variables_Goldstein()
         self.run_mixed_discrete_design_space_example()
-        self.run_hierarchical_design_space_example()
+        if ds.HAS_CONFIG_SPACE:
+            self.run_hierarchical_design_space_example()  # works only with config space impl
 
     def run_mixed_integer_lhs_example(self):
         import numpy as np

--- a/smt/utils/design_space.py
+++ b/smt/utils/design_space.py
@@ -31,6 +31,9 @@ try:
 except ImportError:
     HAS_CONFIG_SPACE = False
 
+    class Configuration:
+        pass
+
     class ConfigurationSpace:
         pass
 


### PR DESCRIPTION
Currently when  `ConfigSpace` not installed, `import smt.surrogate_models` fails.
This PR fixes this issue and add minimal installation tests in CI.