### PR TITLE
Clean internal optimization within Kriging

### DIFF
--- a/smt/applications/mfkpls.py
+++ b/smt/applications/mfkpls.py
@@ -34,6 +34,13 @@ class MFKPLS(MFK):
             desc="Correlation function type",
             types=(str),
         )
+        declare(
+            "hyper_opt",
+            "Cobyla",
+            values=("Cobyla"),
+            desc="Optimiser for hyperparameters optimisation",
+            types=str,
+        )
         declare("n_comp", 1, types=int, desc="Number of principal components")
         self.name = "MFKPLS"
 

--- a/smt/applications/mfkplsk.py
+++ b/smt/applications/mfkplsk.py
@@ -26,6 +26,13 @@ class MFKPLSK(MFKPLS):
             desc="Correlation function type",
             types=(str),
         )
+        declare(
+            "hyper_opt",
+            "Cobyla",
+            values=("Cobyla"),
+            desc="Optimiser for hyperparameters optimisation",
+            types=str,
+        )
         self.name = "MFKPLSK"
 
     def _componentwise_distance(self, dx, opt=0):

--- a/smt/applications/mixed_integer.py
+++ b/smt/applications/mixed_integer.py
@@ -97,7 +97,7 @@ class MixedIntegerSurrogateModel(SurrogateModel):
         """
         super().__init__()
         self._surrogate = surrogate
-
+        self._surrogate.options["hyper_opt"] = "Cobyla"
         if isinstance(self._surrogate, KrgBased):
             raise ValueError(
                 "Using MixedIntegerSurrogateModel integer model with "
@@ -109,7 +109,7 @@ class MixedIntegerSurrogateModel(SurrogateModel):
         self._input_in_folded_space = input_in_folded_space
         self.supports = self._surrogate.supports
         self.options["print_global"] = False
-
+        self.options["hyper_opt"] = "Cobyla"
         if "poly" in self._surrogate.options:
             if self._surrogate.options["poly"] != "constant":
                 raise ValueError("constant regression must be used with mixed integer")
@@ -333,6 +333,7 @@ class MixedIntegerContext(object):
         Build MixedIntegerKrigingModel from given SMT surrogate model.
         """
         surrogate.options["design_space"] = self._design_space
+        surrogate.options["hyper_opt"] = "Cobyla"
         return MixedIntegerKrigingModel(
             surrogate=surrogate,
             input_in_folded_space=self._work_in_folded_space,

--- a/smt/applications/mixed_integer.py
+++ b/smt/applications/mixed_integer.py
@@ -97,7 +97,6 @@ class MixedIntegerSurrogateModel(SurrogateModel):
         """
         super().__init__()
         self._surrogate = surrogate
-        self._surrogate.options["hyper_opt"] = "Cobyla"
         if isinstance(self._surrogate, KrgBased):
             raise ValueError(
                 "Using MixedIntegerSurrogateModel integer model with "
@@ -109,7 +108,6 @@ class MixedIntegerSurrogateModel(SurrogateModel):
         self._input_in_folded_space = input_in_folded_space
         self.supports = self._surrogate.supports
         self.options["print_global"] = False
-        self.options["hyper_opt"] = "Cobyla"
         if "poly" in self._surrogate.options:
             if self._surrogate.options["poly"] != "constant":
                 raise ValueError("constant regression must be used with mixed integer")
@@ -198,6 +196,7 @@ class MixedIntegerKrigingModel(KrgBased):
                 + " is not supported. Please use MixedIntegerSurrogateModel instead."
             )
         self.options["design_space"] = self._surrogate.design_space
+        self._surrogate.options["hyper_opt"] = "Cobyla"
 
         self._input_in_folded_space = input_in_folded_space
         self.supports = self._surrogate.supports

--- a/smt/applications/tests/test_vfm.py
+++ b/smt/applications/tests/test_vfm.py
@@ -68,7 +68,12 @@ class TestVFM(SMTestCase):
         Bridge_candidate = "KRG"
         type_bridge = "Multiplicative"
         optionsLF = {}
-        optionsB = {"theta0": [1e-2] * ndim, "print_prediction": False, "deriv": False}
+        optionsB = {
+            "theta0": [1e-2] * ndim,
+            "print_prediction": False,
+            "deriv": False,
+            "hyper_opt": "Cobyla",
+        }
 
         # Construct low/high fidelity data and validation points
         sampling = LHS(xlimits=funLF.xlimits, criterion="m", random_state=42)
@@ -138,7 +143,12 @@ class TestVFM(SMTestCase):
         Bridge_candidate = "KRG"
         type_bridge = "Multiplicative"
         optionsLF = {}
-        optionsB = {"theta0": [1e-2] * ndim, "print_prediction": False, "deriv": False}
+        optionsB = {
+            "theta0": [1e-2] * ndim,
+            "print_prediction": False,
+            "deriv": False,
+            "hyper_opt": "Cobyla",
+        }
 
         # Construct low/high fidelity data and validation points
         sampling = LHS(xlimits=funLF.xlimits, criterion="m")
@@ -200,7 +210,9 @@ class TestVFM(SMTestCase):
             yp = M.predict_values(np.atleast_2d(xt[0]))
             dyp = M.predict_derivatives(np.atleast_2d(xt[0]), kx=0)
         self.assert_error(yp, np.array([[0.015368, 0.367424]]), atol=2e-2, rtol=3e-2)
-        self.assert_error(dyp, np.array([[0.07007729, 3.619421]]), atol=3e-1, rtol=1e-2)
+        self.assert_error(
+            dyp, np.array([[-3.11718627e-03, 3.19506239e00]]), atol=3e-1, rtol=1e-2
+        )
 
     def test_QP_KRG_additive(self):
         with Silence():
@@ -214,7 +226,7 @@ class TestVFM(SMTestCase):
 
         self.assert_error(yp, np.array([[0.015368, 0.367424]]), atol=1e-2, rtol=1e-2)
         self.assert_error(
-            dyp, np.array([[1.16130832e-03, 4.36712162e00]]), atol=3e-1, rtol=1e-2
+            dyp, np.array([[0.02596425, 4.70243162]]), atol=3e-1, rtol=1e-2
         )
 
     def test_KRG_KRG_mult(self):
@@ -228,7 +240,9 @@ class TestVFM(SMTestCase):
             dyp = M.predict_derivatives(np.atleast_2d(xt[0]), kx=0)
 
         self.assert_error(yp, np.array([[0.015368, 0.367424]]), atol=2e-2, rtol=3e-2)
-        self.assert_error(dyp, np.array([[0.07007729, 3.619421]]), atol=3e-1, rtol=1e-2)
+        self.assert_error(
+            dyp, np.array([[-3.11718627e-03, 3.19506239e00]]), atol=3e-1, rtol=1e-2
+        )
 
     def test_QP_KRG_mult(self):
         with Silence():

--- a/smt/surrogate_models/gekpls.py
+++ b/smt/surrogate_models/gekpls.py
@@ -32,6 +32,13 @@ class GEKPLS(KPLS):
             types=int,
             desc="Number of extra points per training point",
         )
+        declare(
+            "hyper_opt",
+            "Cobyla",
+            values=("Cobyla"),
+            desc="Optimiser for hyperparameters optimisation",
+            types=str,
+        )
         self.supports["training_derivatives"] = True
 
     def _check_param(self):

--- a/smt/surrogate_models/krg_based.py
+++ b/smt/surrogate_models/krg_based.py
@@ -1016,7 +1016,7 @@ class KrgBased(SurrogateModel):
         gamma = par["gamma"]
         Q = par["Q"]
         G = par["G"]
-        sigma_2 = par["sigma2"]
+        sigma_2 = par["sigma2"] + self.options["nugget"]
 
         nb_theta = len(theta)
         grad_red = np.zeros(nb_theta)

--- a/smt/surrogate_models/krg_based.py
+++ b/smt/surrogate_models/krg_based.py
@@ -1908,6 +1908,10 @@ class KrgBased(SurrogateModel):
                                 optimal_theta_res = optimal_theta_res_loop
 
                     elif self.options["hyper_opt"] == "TNC":
+                        if self.options["use_het_noise"]:
+                            raise ValueError(
+                                "For heteroscedastic noise, please use Cobyla"
+                            )
                         theta_all_loops = 10**theta_all_loops
                         for theta0_loop in theta_all_loops:
                             optimal_theta_res_loop = optimize.minimize(
@@ -1916,7 +1920,7 @@ class KrgBased(SurrogateModel):
                                 method="TNC",
                                 jac=grad_minus_reduced_likelihood_function,
                                 bounds=bounds_hyp,
-                                options={"maxiter": 100},
+                                options={"maxfun": 2 * limit},
                             )
                             if optimal_theta_res_loop["fun"] < optimal_theta_res["fun"]:
                                 optimal_theta_res = optimal_theta_res_loop

--- a/smt/surrogate_models/krg_based.py
+++ b/smt/surrogate_models/krg_based.py
@@ -138,7 +138,7 @@ class KrgBased(SurrogateModel):
         )
         declare(
             "hyper_opt",
-            "Cobyla",
+            "TNC",
             values=("Cobyla", "TNC"),
             desc="Optimiser for hyperparameters optimisation",
             types=str,

--- a/smt/surrogate_models/sgp.py
+++ b/smt/surrogate_models/sgp.py
@@ -51,6 +51,13 @@ class SGP(KRG):
             types=(list, np.ndarray),
         )
         declare(
+            "hyper_opt",
+            "Cobyla",
+            values=("Cobyla"),
+            desc="Optimiser for hyperparameters optimisation",
+            types=str,
+        )
+        declare(
             "eval_noise",
             True,  # for SGP evaluate noise by default
             types=bool,

--- a/smt/surrogate_models/tests/test_krg_het_noise.py
+++ b/smt/surrogate_models/tests/test_krg_het_noise.py
@@ -23,7 +23,13 @@ class Test(SMTestCase):
         xt_full = np.array(3 * xt.tolist())
         yt_full = np.concatenate((yt, yt + 0.2 * yt_std_rand, yt - 0.2 * yt_std_rand))
 
-        sm = KRG(theta0=[1.0], eval_noise=True, use_het_noise=True, n_start=1)
+        sm = KRG(
+            theta0=[1.0],
+            eval_noise=True,
+            use_het_noise=True,
+            n_start=1,
+            hyper_opt="Cobyla",
+        )
         sm.set_training_values(xt_full, yt_full)
         sm.train()
 

--- a/smt/tests/test_array_outputs.py
+++ b/smt/tests/test_array_outputs.py
@@ -38,7 +38,7 @@ class ArrayOutputTest(SMTestCase):
             d0 = interp.predict_derivatives(np.atleast_2d(xt[10, :]), 0)
 
         self.assert_error(
-            d0, np.array([[0.06874097, 4.366292277996716]]), atol=0.55, rtol=0.15
+            d0, np.array([[0.24897752, 3.72290526]]), atol=0.55, rtol=0.15
         )
 
     def test_RBF(self):

--- a/smt/tests/test_kpls_auto.py
+++ b/smt/tests/test_kpls_auto.py
@@ -46,7 +46,7 @@ class Test(SMTestCase):
         n_comp_opt["Branin"] = 2
         n_comp_opt["Rosenbrock"] = 1
         n_comp_opt["sphere"] = 1
-        n_comp_opt["exp"] = 2
+        n_comp_opt["exp"] = 3
         n_comp_opt["tanh"] = 1
         n_comp_opt["cos"] = 2
 

--- a/smt/tests/test_kpls_auto.py
+++ b/smt/tests/test_kpls_auto.py
@@ -46,12 +46,9 @@ class Test(SMTestCase):
         n_comp_opt["Branin"] = 2
         n_comp_opt["Rosenbrock"] = 1
         n_comp_opt["sphere"] = 1
-        if platform.startswith("linux"):  # result depends on platform
-            n_comp_opt["exp"] = 2
-        else:
-            n_comp_opt["exp"] = 3
+        n_comp_opt["exp"] = 2
         n_comp_opt["tanh"] = 1
-        n_comp_opt["cos"] = 1
+        n_comp_opt["cos"] = 2
 
         self.nt = nt
         self.ne = ne


### PR DESCRIPTION
Two optimizers are available within Kriging: TNC that is gradient-based vs Cobyla that is gradient-free.

This PR fix TNC as a default optimizer whenever the derivative of the likelihood is available and Cobyla otherwise.

The distinction between where TNC is available and where it is not has been made more clear.