### PR TITLE
remove numba for matrix_data_corr_levels_cat_matrix to handle python 3.10 without bugs 

### DIFF
--- a/smt/utils/kriging.py
+++ b/smt/utils/kriging.py
@@ -1550,7 +1550,6 @@ def quadratic(x):
     return f
 
 
-@njit_use(parallel=True)
 def matrix_data_corr_levels_cat_matrix(
     i, n_levels, theta_cat, theta_bounds, is_ehh: bool
 ):


### PR DESCRIPTION
https://github.com/jbussemaker/SBArchOpt/pull/18 for more infos

ERROR WAS : 

(375 durations < 0.005s hidden.  Use -vv to show these durations.)
=========================== short test summary info ============================
FAILED sb_arch_opt/tests/algo/test_arch_sbo.py::test_smt_krg_features - numba.core.errors.TypingError: Failed in nopython mode pipeline (step: nopython frontend)
No implementation of function Function(<built-in function setitem>) found for signature:
 
 >>> setitem(array(float64, 2d, C), UniTuple(int64 x 2), array(float64, 1d, C))
 
There are 16 candidate implementations:
      - Of which 16 did not match due to:
      Overload of function 'setitem': File: <numerous>: Line N/A.
        With argument(s): '(array(float64, 2d, C), UniTuple(int64 x 2), array(float64, 1d, C))':
       No match.

During: typing of setitem at /opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/smt/utils/kriging.py (1565)

File "../../../../../opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/smt/utils/kriging.py", line 1565:
def matrix_data_corr_levels_cat_matrix(
    <source elided>
            else:
                Theta_mat[j, k + j] = theta_cat[v]
                ^