### PR TITLE
Remove some warnings

### DIFF
--- a/smt/applications/mixed_integer.py
+++ b/smt/applications/mixed_integer.py
@@ -38,10 +38,6 @@ class MixedIntegerSamplingMethod(SamplingMethod):
             specifying if doe output should be in folded space (enum indexes)
             or not (enum masks)
         """
-        warnings.warn(
-            "MixedIntegerSamplingMethod has been deprecated, use DesignSpace.sample_valid_x instead!",
-            category=DeprecationWarning,
-        )
         self._design_space = design_space
         if "random_state" in kwargs:
             self._design_space.random_state = kwargs["random_state"]
@@ -56,7 +52,6 @@ class MixedIntegerSamplingMethod(SamplingMethod):
         super().__init__(xlimits=self._unfolded_xlimits)
 
     def _compute(self, nt, return_is_acting=False):
-
         x_doe, is_acting = self._design_space.sample_valid_x(
             nt,
             unfolded=not self._output_in_folded_space,
@@ -227,9 +222,9 @@ class MixedIntegerKrigingModel(KrgBased):
             )
             and self._surrogate.options["categorical_kernel"] is None
         ):
-            self._surrogate.options["categorical_kernel"] = (
-                MixIntKernelType.HOMO_HSPHERE
-            )
+            self._surrogate.options[
+                "categorical_kernel"
+            ] = MixIntKernelType.HOMO_HSPHERE
             warnings.warn(
                 "Using MixedIntegerSurrogateModel integer model with Continuous Relaxation is not supported. Switched to homoscedastic hypersphere kernel instead."
             )

--- a/smt/applications/moe.py
+++ b/smt/applications/moe.py
@@ -11,15 +11,12 @@ Mixture of Experts
 # TODO : documentation
 
 import numpy as np
-import warnings
 
 from sklearn.mixture import GaussianMixture
 from scipy.stats import multivariate_normal
 
 from smt.applications.application import SurrogateBasedApplication
 from smt.surrogate_models.surrogate_model import SurrogateModel
-
-warnings.filterwarnings("ignore", category=DeprecationWarning)
 
 MOE_EXPERT_NAMES = [
     "KRG",

--- a/smt/applications/tests/test_ego.py
+++ b/smt/applications/tests/test_ego.py
@@ -4,8 +4,6 @@ Author: Remi Lafage <remi.lafage@onera.fr> and Nathalie Bartoli
 This package is distributed under New BSD license.
 """
 
-import warnings
-
 import os
 import unittest
 import numpy as np

--- a/smt/applications/tests/test_ego.py
+++ b/smt/applications/tests/test_ego.py
@@ -817,7 +817,7 @@ class TestEGO(SMTestCase):
         criterion = "LCB"  #'EI' or 'SBO' or 'LCB'
         random_state = 42
         design_space = DesignSpace(xlimits, random_state=random_state)
-        xdoe = FullFactorial(xlimits=xlimits)(10)
+        xdoe = FullFactorial(xlimits=xlimits)(9)
         ydoe = fun(xdoe)
         ego = EGO(
             xdoe=xdoe,
@@ -1140,7 +1140,7 @@ class TestEGO(SMTestCase):
                 x_plot.T[0], sig_plus.T[0], sig_moins.T[0], alpha=0.3, color="g"
             )
             lines = [true_fun, data, gp, un_gp, opt, ei]
-            fig.suptitle("EGO optimization of $f(x) = x \sin{x}$")
+            fig.suptitle("EGO optimization of $f(x) = x \\sin{x}$")
             fig.subplots_adjust(hspace=0.4, wspace=0.4, top=0.8)
             ax.set_title("iteration {}".format(i + 1))
             fig.legend(
@@ -1377,7 +1377,7 @@ class TestEGO(SMTestCase):
                     x_plot.T[0], sig_plus.T[0], sig_moins.T[0], alpha=0.3, color="g"
                 )
                 lines = [true_fun, data, gp, un_gp, opt, ei, virt_data]
-                fig.suptitle("EGOp optimization of $f(x) = x \sin{x}$")
+                fig.suptitle("EGOp optimization of $f(x) = x \\sin{x}$")
                 fig.subplots_adjust(hspace=0.4, wspace=0.4, top=0.8)
                 ax.set_title("iteration {}.{}".format(i, p))
                 fig.legend(

--- a/smt/applications/tests/test_ego.py
+++ b/smt/applications/tests/test_ego.py
@@ -36,8 +36,6 @@ from smt.applications.mixed_integer import (
 )
 import smt.utils.design_space as ds
 
-warnings.filterwarnings("ignore")
-
 try:
     import matplotlib
 

--- a/smt/applications/tests/test_mfk_mfkpls_mixed.py
+++ b/smt/applications/tests/test_mfk_mfkpls_mixed.py
@@ -36,16 +36,12 @@ from smt.surrogate_models import (
     MixIntKernelType,
 )
 
-import warnings
-
 from smt.utils.design_space import (
     DesignSpace,
     FloatVariable,
     IntegerVariable,
     CategoricalVariable,
 )
-
-warnings.filterwarnings("ignore")
 
 
 class TestMFKmixed(unittest.TestCase):

--- a/smt/problems/robot_arm.py
+++ b/smt/problems/robot_arm.py
@@ -58,6 +58,9 @@ class RobotArm(Problem):
         y = np.zeros((ne, 1), complex)
         d_pos_x = np.zeros(ne, complex)
         d_pos_y = np.zeros(ne, complex)
+
+        # To remove warning: NaN can be ignored
+        np.seterr(invalid="ignore")
         if kx is None:
             y[:, 0] = (pos_x**2 + pos_y**2) ** 0.5
         else:

--- a/smt/surrogate_models/tests/test_kpls.py
+++ b/smt/surrogate_models/tests/test_kpls.py
@@ -46,25 +46,6 @@ class TestKPLS(unittest.TestCase):
             kriging.set_training_values(x, y)
             self.assertRaises(ValueError, lambda: kriging.train())
 
-    def test_kpls_training_with_zeroed_outputs(self):
-        # Test scikit-learn 0.24 regression cf. https://github.com/SMTorg/smt/issues/274
-        for corr_str in [
-            "pow_exp",
-            "abs_exp",
-            "squar_exp",
-        ]:
-            x = np.random.rand(50, 3)
-            y = np.zeros(50)
-
-            kpls = KPLS()
-            kpls.options["corr"] = corr_str
-            kpls.set_training_values(x, y)
-            kpls.train()
-            x_test = np.asarray([[0, 0, 0], [0.5, 0.5, 0.5], [1, 1, 1]])
-            y_test = kpls.predict_values(x_test)
-            # KPLS training fails anyway but not due to PLS exception StopIteration
-            self.assertEqual(np.linalg.norm(y_test - np.asarray([[0, 0, 0]])), 0)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/smt/utils/neural_net/model.py
+++ b/smt/utils/neural_net/model.py
@@ -518,9 +518,9 @@ class Model(object):
         plt.xlabel("Absolute Prediction Error")
         plt.ylabel("Probability")
         plt.title(
-            "$\mu$="
+            "$\\mu$="
             + str(metrics["avg_error"])
-            + ", $\sigma=$"
+            + ", $\\sigma=$"
             + str(metrics["std_error"])
         )
         plt.grid(True)


### PR DESCRIPTION
This PR deals with some warnings raised with: 
* Python 3.8
* numpy 1.23.4, 
* scipy 1.10.1, 
* scikit-learn 1.3.1, 
* numba 0.57.0
* ConfigSpace 0.6.1

CI tests will present warnings triggered by more recent versions of those dependencies