### PR TITLE
 fix cliping predictions 

### DIFF
--- a/doc/_src_docs/surrogate_models/krg.rst
+++ b/doc/_src_docs/surrogate_models/krg.rst
@@ -366,7 +366,7 @@ Options
      -  Regression function type
   *  -  corr
      -  squar_exp
-     -  ['pow_exp', 'abs_exp', 'squar_exp', 'matern52', 'matern32']
+     -  ['pow_exp', 'abs_exp', 'squar_exp', 'squar_sin_exp', 'matern52', 'matern32']
      -  ['str']
      -  Correlation function type
   *  -  pow_exp_power

--- a/smt/applications/mixed_integer.py
+++ b/smt/applications/mixed_integer.py
@@ -222,9 +222,9 @@ class MixedIntegerKrigingModel(KrgBased):
             )
             and self._surrogate.options["categorical_kernel"] is None
         ):
-            self._surrogate.options[
-                "categorical_kernel"
-            ] = MixIntKernelType.HOMO_HSPHERE
+            self._surrogate.options["categorical_kernel"] = (
+                MixIntKernelType.HOMO_HSPHERE
+            )
             warnings.warn(
                 "Using MixedIntegerSurrogateModel integer model with Continuous Relaxation is not supported. \
                     Switched to homoscedastic hypersphere kernel instead."

--- a/smt/applications/tests/test_ego.py
+++ b/smt/applications/tests/test_ego.py
@@ -1404,5 +1404,4 @@ if __name__ == "__main__":
     if "--example" in argv:
         TestEGO.run_ego_mixed_integer_example()
         exit()
-    # unittest.main()
-    TestEGO().test_ego_random_stateing()
+    unittest.main()

--- a/smt/applications/tests/test_ego.py
+++ b/smt/applications/tests/test_ego.py
@@ -1009,8 +1009,8 @@ class TestEGO(SMTestCase):
         )
         x_opt, y_opt, dnk, x_data, y_data = ego.optimize(fun=f_obj)
         if ds.HAS_CONFIG_SPACE:  # results differs wrt config_space impl
-            self.assertAlmostEqual(np.sum(y_data), 6.768616104127338, delta=1e-6)
-            self.assertAlmostEqual(np.sum(x_data), 34.205904294464716, delta=1e-6)
+            self.assertAlmostEqual(np.sum(y_data), 5.4385331120184475, delta=1e-3)
+            self.assertAlmostEqual(np.sum(x_data), 39.711522540205394, delta=1e-3)
         else:
             self.assertAlmostEqual(np.sum(y_data), 1.8911720670620835, delta=1e-6)
             self.assertAlmostEqual(np.sum(x_data), 47.56885202767958, delta=1e-6)
@@ -1404,4 +1404,5 @@ if __name__ == "__main__":
     if "--example" in argv:
         TestEGO.run_ego_mixed_integer_example()
         exit()
-    unittest.main()
+    # unittest.main()
+    TestEGO().test_ego_random_stateing()

--- a/smt/surrogate_models/krg.py
+++ b/smt/surrogate_models/krg.py
@@ -17,7 +17,14 @@ class KRG(KrgBased):
         declare(
             "corr",
             "squar_exp",
-            values=("pow_exp", "abs_exp", "squar_exp", "matern52", "matern32"),
+            values=(
+                "pow_exp",
+                "abs_exp",
+                "squar_exp",
+                "squar_sin_exp",
+                "matern52",
+                "matern32",
+            ),
             desc="Correlation function type",
             types=(str),
         )

--- a/smt/surrogate_models/krg_based.py
+++ b/smt/surrogate_models/krg_based.py
@@ -244,7 +244,9 @@ class KrgBased(SurrogateModel):
             xt = xt[0][0]
 
         if self.options["design_space"] is None:
-            self.options["design_space"] = ensure_design_space(xt=xt)
+            self.options["design_space"] = ensure_design_space(
+                xt=xt, xlimits=self.options["xlimits"]
+            )
 
         elif not isinstance(self.options["design_space"], BaseDesignSpace):
             ds_input = self.options["design_space"]

--- a/smt/surrogate_models/tests/test_surrogate_model_examples.py
+++ b/smt/surrogate_models/tests/test_surrogate_model_examples.py
@@ -814,9 +814,9 @@ class Test(unittest.TestCase):
         genn.options["hidden_layer_sizes"] = [6, 6]
         genn.options["alpha"] = 0.1
         genn.options["lambd"] = 0.1
-        genn.options[
-            "gamma"
-        ] = 1.0  # 1 = gradient-enhanced on, 0 = gradient-enhanced off
+        genn.options["gamma"] = (
+            1.0  # 1 = gradient-enhanced on, 0 = gradient-enhanced off
+        )
         genn.options["num_iterations"] = 1000
         genn.options["is_backtracking"] = True
         genn.options["is_normalize"] = False

--- a/smt/tests/test_all.py
+++ b/smt/tests/test_all.py
@@ -173,7 +173,7 @@ class Test(SMTestCase):
         elif pname == "tanh" and sname in ["KPLS", "RMTB"]:
             self.assertLessEqual(e_error, self.e_errors[sname] + 0.4)
         elif pname == "exp" and sname in ["GENN"]:
-            self.assertLessEqual(e_error, 1e-1)
+            self.assertLessEqual(e_error, 1.5e-1)
         elif pname == "exp" and sname in ["RMTB"]:
             self.assertLessEqual(e_error, self.e_errors[sname] + 0.5)
         else:

--- a/smt/utils/design_space.py
+++ b/smt/utils/design_space.py
@@ -1179,8 +1179,8 @@ class DesignSpace(BaseDesignSpace):
         for i, dv in enumerate(self.design_variables):
             if isinstance(dv, FloatVariable):
                 if cs_normalize:
-                    dv.lower = min(np.min(x), dv.lower)
-                    dv.upper = max(np.max(x), dv.upper)
+                    dv.lower = min(np.min(x[:, i]), dv.lower)
+                    dv.upper = max(np.max(x[:, i]), dv.upper)
                     x[:, i] = np.clip(
                         (x[:, i] - dv.lower) / (dv.upper - dv.lower + 1e-16), 0, 1
                     )

--- a/smt/utils/design_space.py
+++ b/smt/utils/design_space.py
@@ -1179,6 +1179,8 @@ class DesignSpace(BaseDesignSpace):
         for i, dv in enumerate(self.design_variables):
             if isinstance(dv, FloatVariable):
                 if cs_normalize:
+                    dv.lower = min(np.min(x), dv.lower)
+                    dv.upper = max(np.max(x), dv.upper)
                     x[:, i] = np.clip(
                         (x[:, i] - dv.lower) / (dv.upper - dv.lower + 1e-16), 0, 1
                     )


### PR DESCRIPTION
- Fix a bug in which the max bound was set to the max of the training database when normalizing data
- Fix a bug: ensure_design_space was not checking xlimits
- Update the documentation and add the sin exp kernel to the list of available kernels in KRG