### PR TITLE
Fix signed integer overflow

### DIFF
--- a/smt/src/rmts/rmtc.cpp
+++ b/smt/src/rmts/rmtc.cpp
@@ -161,11 +161,11 @@ void RMTC::compute_uniq2elem(double * data, int * rows, int * cols) {
 }
 
 void RMTC::compute_full_from_block(double * mtx, double * data, int * rows, int * cols){
-  int inz = 0;
+  long inz = 0;
 
-  for (int ielem = 0; ielem < nelem; ielem++) {
-    for (int iterm1 = 0; iterm1 < nterm; iterm1++) {
-      for (int iterm2 = 0; iterm2 < nterm; iterm2++) {
+  for (long ielem = 0; ielem < nelem; ielem++) {
+    for (long iterm1 = 0; iterm1 < nterm; iterm1++) {
+      for (long iterm2 = 0; iterm2 < nterm; iterm2++) {
         data[inz] = mtx[iterm1 * nterm + iterm2];
         rows[inz] = ielem * nterm + iterm1;
         cols[inz] = ielem * nterm + iterm2;

--- a/smt/src/rmts/rmtc.hpp
+++ b/smt/src/rmts/rmtc.hpp
@@ -18,7 +18,7 @@ private:
   void find_interval(int ix, int num, double x, int * index, double * xbar);
   int * nelem_list;
   int * nterm_list;
-  int nelem, nterm;
+  long nelem, nterm;
 };
 
 #endif


### PR DESCRIPTION
In Issue #571, I encountered a bus error.
Using AddressSanitizer, I traced the error to a negative memory index caused by a 32 bit signed integer overflowing the bounds and requesting memory from a negative index.

Swap out `int` for `long` so that more total memory can be addressed and allow larger problem sizes.