### PR TITLE
Support for Python 3.12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,12 +13,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.11"]
+        python-version: ["3.12"]
         include:
           - os: ubuntu-latest
-            python-version: "3.10"
+            python-version: "3.11"
           - os: ubuntu-latest
-            python-version: "3.9"
+            python-version: "3.10"
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/tests_minimal.yml
+++ b/.github/workflows/tests_minimal.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.8"
+        python-version: "3.9"
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/tests_minimal.yml
+++ b/.github/workflows/tests_minimal.yml
@@ -24,7 +24,7 @@ jobs:
 
     - name: Test with pytest
       run: |
-        pip install pytest==8.0.1 pytest-xdist
-        pytest -n auto smt
+        pip install pytest
+        pytest smt
 
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -5,7 +5,6 @@ scikit-learn
 pyDOE3
 numpydoc
 matplotlib
-ConfigSpace ~= 0.6.1
 jenn >= 1.0.2, <2.0
 egobox ~= 0.18.0
 git+https://github.com/hwangjt/sphinx_auto_embed.git  # for doc generation 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,5 +1,5 @@
 Cython
-numpy <2.0
+numpy
 scipy
 scikit-learn
 pyDOE3

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,5 @@ pytest ~= 8.0.1 # tests runner
 pytest-xdist    # allows running parallel testing with pytest -n <num_workers>
 pytest-cov      # allows to get coverage report
 ruff            # format and lint code
-ConfigSpace ~= 0.6.1
 jenn >= 1.0.2, <2.0
 egobox ~= 0.19.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Cython
-numpy <2.0
+numpy
 scipy
 scikit-learn
 pyDOE3

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ scikit-learn
 pyDOE3
 numba           # JIT compiler
 matplotlib      # used in examples and tests
-pytest ~= 8.0.1 # tests runner
+pytest          # tests runner
 pytest-xdist    # allows running parallel testing with pytest -n <num_workers>
 pytest-cov      # allows to get coverage report
 ruff            # format and lint code


### PR DESCRIPTION
This PR drops testing with py3.8 and starts testing with py3.12