### PR TITLE
Document example with less expensive parameters

### DIFF
--- a/doc/_src_docs/surrogate_models/rmts.rst
+++ b/doc/_src_docs/surrogate_models/rmts.rst
@@ -204,7 +204,7 @@ Usage (RMTC)
   
   sm = RMTC(
       xlimits=xlimits,
-      num_elements=20,
+      num_elements=6,
       energy_weight=1e-15,
       regularization_weight=0.0,
   )

--- a/smt/surrogate_models/tests/test_surrogate_model_examples.py
+++ b/smt/surrogate_models/tests/test_surrogate_model_examples.py
@@ -131,7 +131,7 @@ class Test(unittest.TestCase):
 
         sm = RMTC(
             xlimits=xlimits,
-            num_elements=20,
+            num_elements=6,
             energy_weight=1e-15,
             regularization_weight=0.0,
         )


### PR DESCRIPTION
The documentation for RMTC uses `num_elements=20`. In Issue #574, it is shown that the training time is exponential in `num_elements`.
Hence using copy-paste from the example can blow up the compute time.

Reduce `num_elements` in the example so that users are less likely to hit this exponential behavior.