### PR TITLE
Test with ConfigSpace on py3.11

### DIFF
--- a/.github/workflows/tests_coverage.yml
+++ b/.github/workflows/tests_coverage.yml
@@ -28,6 +28,7 @@ jobs:
       run: |
         pip install --upgrade pip
         pip install -r requirements.txt
+        pip install ConfigSpace==0.6.1
         pip list
         pip install -e .
 

--- a/.github/workflows/tests_coverage.yml
+++ b/.github/workflows/tests_coverage.yml
@@ -27,8 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install ConfigSpace==0.6.1
+        pip install -r requirements.txt numpy==1.26.4 ConfigSpace==0.6.1
         pip list
         pip install -e .
 


### PR DESCRIPTION
Following #575, this PR restores coverage test with ConfigSpace on python 3.11 and numpy 1.26.4.