### PR TITLE
fix ei warning divide by zero

### DIFF
--- a/smt/applications/ego.py
+++ b/smt/applications/ego.py
@@ -192,7 +192,9 @@ class EGO(SurrogateBasedApplication):
         sig = np.sqrt(self.gpr.predict_variances(points))
         args0 = (f_min - pred) * 1e-13
         args1 = (f_min - pred) * 1e-13
-        if np.abs(sig) > 1e-12:
+        if (sig.size == 1 and np.abs(sig) > 1e-12) or (
+            sig.size > 1 and np.min(np.abs(sig)) > 1e-12
+        ):
             args0 = (f_min - pred) / sig
             args1 = (f_min - pred) * norm.cdf(args0)
         args2 = sig * norm.pdf(args0)

--- a/smt/applications/ego.py
+++ b/smt/applications/ego.py
@@ -190,10 +190,15 @@ class EGO(SurrogateBasedApplication):
         f_min = y_data[np.argmin(y_data[:, 0])]
         pred = self.gpr.predict_values(points)
         sig = np.sqrt(self.gpr.predict_variances(points))
-        args0 = (f_min - pred) / sig
-        args1 = (f_min - pred) * norm.cdf(args0)
+        args0 = (f_min - pred) * 1e-13
+        args1 = (f_min - pred) * 1e-13
+        if np.abs(sig) > 1e-12:
+            args0 = (f_min - pred) / sig
+            args1 = (f_min - pred) * norm.cdf(args0)
         args2 = sig * norm.pdf(args0)
-        if sig.size == 1 and sig == 0.0:  # can be use only if one point is computed
+        if (
+            sig.size == 1 and np.abs(sig) < 1e-12
+        ):  # can be use only if one point is computed
             return 0.0
         ei = args1 + args2
         # penalize the points already evaluated with tunneling

--- a/smt/applications/ego.py
+++ b/smt/applications/ego.py
@@ -192,16 +192,19 @@ class EGO(SurrogateBasedApplication):
         sig = np.sqrt(self.gpr.predict_variances(points))
         args0 = (f_min - pred) * 1e-13
         args1 = (f_min - pred) * 1e-13
-        if (sig.size == 1 and np.abs(sig) > 1e-12) or (
-            sig.size > 1 and np.min(np.abs(sig)) > 1e-12
-        ):
+        if sig.size == 1 and np.abs(sig) > 1e-12:
             args0 = (f_min - pred) / sig
             args1 = (f_min - pred) * norm.cdf(args0)
-        args2 = sig * norm.pdf(args0)
+        elif sig.size > 1:
+            for i, sigma in enumerate(list(sig[0])):
+                if np.abs(sigma) > 1e-12:
+                    args0[0][i] = (f_min[i] - pred[0][i]) / sigma
+                    args1[0][i] = (f_min[i] - pred[0][i]) * norm.cdf(args0[0][i])
         if (
             sig.size == 1 and np.abs(sig) < 1e-12
         ):  # can be use only if one point is computed
             return 0.0
+        args2 = sig * norm.pdf(args0)
         ei = args1 + args2
         # penalize the points already evaluated with tunneling
         if enable_tunneling:

--- a/smt/applications/ego.py
+++ b/smt/applications/ego.py
@@ -190,8 +190,11 @@ class EGO(SurrogateBasedApplication):
         f_min = y_data[np.argmin(y_data[:, 0])]
         pred = self.gpr.predict_values(points)
         sig = np.sqrt(self.gpr.predict_variances(points))
-        args0 = (f_min - pred) * 1e-13
-        args1 = (f_min - pred) * 1e-13
+
+        # initialization good format (array or scalar)
+        args0 = (f_min - pred) * 0.0
+        args1 = (f_min - pred) * 0.0
+
         if sig.size == 1 and np.abs(sig) > 1e-12:
             args0 = (f_min - pred) / sig
             args1 = (f_min - pred) * norm.cdf(args0)

--- a/smt/applications/tests/test_ego.py
+++ b/smt/applications/tests/test_ego.py
@@ -1125,9 +1125,22 @@ class TestEGO(SMTestCase):
         ego._train_gpr(x_data, y_data)
 
         # Test the EI value at the following point
-        ei = ego.EI(np.array([[0.8398599985874058, -0.3240337426231973]]))
+        ei = ego.EI(
+            np.array(
+                [[0.8398599985874058, -0.3240337426231973], [-0.45961638, 0.40808533]]
+            )
+        )
 
-        self.assertTrue(np.allclose(ei, [6.87642e-12, 1.47804e-10, 2.76223], atol=1e-1))
+        self.assertTrue(
+            np.allclose(
+                ei,
+                [
+                    [6.87642e-12, 1.47804e-10, 2.76223],
+                    [0.00000000e00, 0.00000000e00, 0.00000000e00],
+                ],
+                atol=1e-2,
+            )
+        )
 
     def test_qei_criterion_default(self):
         fun = TestEGO.function_test_1d

--- a/smt/surrogate_models/tests/test_krg_predictions.py
+++ b/smt/surrogate_models/tests/test_krg_predictions.py
@@ -140,7 +140,9 @@ class Test(SMTestCase):
         deriv = np.array(
             [sm.predict_derivatives(x, 0)[0], sm.predict_derivatives(x, 1)[0]]
         ).T
-        np.testing.assert_allclose(deriv, np.array([[diff_g,diff_d]]), atol=1e-2, rtol=1e-2)
+        np.testing.assert_allclose(
+            deriv, np.array([[diff_g, diff_d]]), atol=1e-2, rtol=1e-2
+        )
 
         ### VECTORIZATION TESTS
 


### PR DESCRIPTION
- Fix EI warning "divide by zero" that was raise because we devided by sigma before verifying it was not too small.