### PR TITLE
New methods to induce points in SGP

### DIFF
--- a/smt/surrogate_models/sgp.py
+++ b/smt/surrogate_models/sgp.py
@@ -10,6 +10,8 @@ Sparse GP implementations of GPy project. See https://github.com/SheffieldML/GPy
 
 import numpy as np
 from scipy import linalg
+from scipy.cluster.vq import kmeans
+
 
 from smt.surrogate_models.krg import KRG
 from smt.utils.checks import ensure_2d_array
@@ -81,6 +83,13 @@ class SGP(KRG):
             types=(str),
         )
         declare("n_inducing", 10, desc="Number of inducing inputs", types=int)
+        declare(
+            "inducing_method",
+            "random",
+            types=str,
+            values=["random", "kmeans"],
+            desc="The chosen method to induce points",
+        )
 
         supports = self.supports
         supports["derivatives"] = False
@@ -96,7 +105,8 @@ class SGP(KRG):
     def set_inducing_inputs(self, Z=None, normalize=False):
         """
         Define number of inducing inputs or set the locations manually.
-        When Z is not specified then points are picked randomly amongst the inputs training set.
+        When Z is not specified then points are picked either randomly or with the kmeans method
+        amongst the inputs training set.
 
         Parameters
         ----------
@@ -106,19 +116,24 @@ class SGP(KRG):
             Inducing inputs.
         normalize : When Z is given, whether values should be normalized
         """
+        X = self.training_points[None][0][0]  # [nt,nx]
+        y = self.training_points[None][0][1]
         if Z is None:
             self.nz = self.options["n_inducing"]
-            X = self.training_points[None][0][0]  # [nt,nx]
-            random_idx = np.random.permutation(self.nt)[: self.nz]
-            self.Z = X[random_idx].copy()  # [nz,nx]
+            # We randomly induce points
+            if self.options["inducing_method"] == "random":
+                idx = np.random.permutation(self.nt)[: self.nz]
+                self.Z = X[idx].copy()  # [nz,nx]
+            # We induce points with the kmeans method
+            else:
+                data = np.hstack((X, y))
+                self.Z = kmeans(data, self.nz)[0][:, :-1]
         else:
             Z = ensure_2d_array(Z, "Z")
             if self.nx != Z.shape[1]:
                 raise ValueError("DimensionError: Z.shape[1] != X.shape[1]")
             self.Z = Z  # [nz,nx]
             if normalize:
-                X = self.training_points[None][0][0]  # [nt,nx]
-                y = self.training_points[None][0][1]
                 self.normalize = True
                 (
                     _,

--- a/smt/surrogate_models/tests/test_sgp.py
+++ b/smt/surrogate_models/tests/test_sgp.py
@@ -75,6 +75,31 @@ class TestSGP(SMTestCase):
         self.assert_error(Ypred, self.Ytest, atol=0.05, rtol=0.2)
         self.assertAlmostEqual(sgp.optimal_noise, self.eta[0], delta=2.9e-2)
 
+    def test_fitc_with_kmeans(self):
+        sgp = SGP(n_inducing=30, inducing_method="kmeans")
+        sgp.set_training_values(self.Xtrain, self.Ytrain)
+        sgp.train()
+
+        Ypred = sgp.predict_values(self.Xtest)
+        self.assert_error(Ypred, self.Ytest, atol=0.05, rtol=0.2)
+
+    def test_vfe_with_random(self):
+        sgp = SGP(method="VFE", n_inducing=30, inducing_method="random")
+        sgp.set_training_values(self.Xtrain, self.Ytrain)
+        sgp.train()
+
+        Ypred = sgp.predict_values(self.Xtest)
+        self.assert_error(Ypred, self.Ytest, atol=0.05, rtol=0.2)
+
+    def test_inducing_error(self):
+        sgp = SGP()
+        sgp.set_training_values(self.Xtrain, self.Ytrain)
+        with self.assertRaises(
+            ValueError,
+            msg="Specify inducing points with set_inducing_inputs() or set inducing_method option",
+        ):
+            sgp.train()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR aims to enable the choice of the method for inducing points. It can either provide a set of induced points or directly specify the number of points to induce along with the method. As for the method, it can either induce points randomly or use the k-means method.