### PR TITLE
fix CR and hier, twice corrected

### DIFF
--- a/doc/_src_docs/applications/Mixed_Hier_surr.rst
+++ b/doc/_src_docs/applications/Mixed_Hier_surr.rst
@@ -1,8 +1,10 @@
 .. _Mixed Integer and hierarchical Surrogates:
 
-Mixed integer surrogate
-=======================
+Mixed Integer and hierarchical Surrogates
+=========================================
 
+Mixed Integer Surrogates
+------------------------
 To use a surrogate with mixed integer constraints, the user instantiates a ``MixedIntegerSurrogateModel`` with the given surrogate.
 The ``MixedIntegerSurrogateModel`` implements the ``SurrogateModel`` interface  and decorates the given surrogate while respecting integer and categorical types.
 They are various surrogate models implemented that are described below.

--- a/doc/_src_docs/applications/Mixed_Hier_surr.rstx
+++ b/doc/_src_docs/applications/Mixed_Hier_surr.rstx
@@ -1,8 +1,10 @@
 .. _Mixed Integer and hierarchical Surrogates:
 
-Mixed integer surrogate
-=======================
+Mixed Integer and hierarchical Surrogates
+=========================================
 
+Mixed Integer Surrogates
+------------------------
 To use a surrogate with mixed integer constraints, the user instantiates a ``MixedIntegerSurrogateModel`` with the given surrogate.
 The ``MixedIntegerSurrogateModel`` implements the ``SurrogateModel`` interface  and decorates the given surrogate while respecting integer and categorical types.
 They are various surrogate models implemented that are described below.

--- a/smt/applications/tests/test_mixed_integer.py
+++ b/smt/applications/tests/test_mixed_integer.py
@@ -663,9 +663,8 @@ class TestMixedInteger(unittest.TestCase):
 
         y_sv = sm.predict_variances(Xt)[:, 0]
         var_RMSE = np.linalg.norm(y_sv) / len(Yt)
-        self.assertTrue(pred_RMSE < 1e-7)
-        print("Pred_RMSE", pred_RMSE)
-        self.assertTrue(var_RMSE < 1e-7)
+        self.assertLess(pred_RMSE, 1e-7)
+        self.assertLess(var_RMSE, 1e-7)
         self.assertTrue(
             np.linalg.norm(
                 sm.predict_values(

--- a/smt/applications/tests/test_mixed_integer.py
+++ b/smt/applications/tests/test_mixed_integer.py
@@ -1058,10 +1058,10 @@ class TestMixedInteger(unittest.TestCase):
             sm.train()
             y_s = sm.predict_values(Xt)[:, 0]
             _pred_RMSE = np.linalg.norm(y_s - Yt) / len(Yt)
-            self.assertTrue(_pred_RMSE < 1e-7)
+            self.assertLess(_pred_RMSE, 1e-7)
             y_sv = sm.predict_variances(Xt)[:, 0]
             _var_RMSE = np.linalg.norm(y_sv) / len(Yt)
-            self.assertTrue(_var_RMSE < 1e-7)
+            self.assertLess(_var_RMSE, 1e-7)
             np.testing.assert_almost_equal(
                 sm.predict_values(
                     np.array(
@@ -1324,9 +1324,8 @@ class TestMixedInteger(unittest.TestCase):
 
         y_sv = sm.predict_variances(Xt)[:, 0]
         var_RMSE = np.linalg.norm(y_sv) / len(Yt)
-        self.assertTrue(pred_RMSE < 1e-7)
-        print("Pred_RMSE", pred_RMSE)
-        self.assertTrue(var_RMSE < 1e-7)
+        self.assertLess(pred_RMSE, 1e-7)
+        self.assertLess(var_RMSE, 1e-7)
         np.testing.assert_almost_equal(
             sm.predict_values(
                 np.array(

--- a/smt/applications/tests/test_mixed_integer.py
+++ b/smt/applications/tests/test_mixed_integer.py
@@ -1040,6 +1040,8 @@ class TestMixedInteger(unittest.TestCase):
         for mixint_kernel in [
             MixIntKernelType.CONT_RELAX,
             MixIntKernelType.GOWER,
+            MixIntKernelType.COMPOUND_SYMMETRY,
+            MixIntKernelType.EXP_HOMO_HSPHERE,
             MixIntKernelType.HOMO_HSPHERE,
         ]:
             sm = MixedIntegerKrigingModel(
@@ -1057,10 +1059,10 @@ class TestMixedInteger(unittest.TestCase):
             sm.train()
             y_s = sm.predict_values(Xt)[:, 0]
             _pred_RMSE = np.linalg.norm(y_s - Yt) / len(Yt)
-
+            self.assertTrue(_pred_RMSE < 1e-7)
             y_sv = sm.predict_variances(Xt)[:, 0]
             _var_RMSE = np.linalg.norm(y_sv) / len(Yt)
-
+            self.assertTrue(_var_RMSE < 1e-7)
             np.testing.assert_almost_equal(
                 sm.predict_values(
                     np.array(

--- a/smt/surrogate_models/krg_based.py
+++ b/smt/surrogate_models/krg_based.py
@@ -463,14 +463,6 @@ class KrgBased(SurrogateModel):
                 listcatdecreed = self.design_space.is_conditionally_acting[
                     self.cat_features
                 ]
-                if np.any(listcatdecreed):
-                    D = self._correct_distances_cat_decreed(
-                        D,
-                        is_acting,
-                        listcatdecreed,
-                        self.ij,
-                        mixint_type=MixIntKernelType.CONT_RELAX,
-                    )
 
             # Center and scale X_cont and y
             (
@@ -1485,15 +1477,6 @@ class KrgBased(SurrogateModel):
                 listcatdecreed = self.design_space.is_conditionally_acting[
                     self.cat_features
                 ]
-                if np.any(listcatdecreed):
-                    dx = self._correct_distances_cat_decreed(
-                        dx,
-                        is_acting,
-                        listcatdecreed,
-                        ij,
-                        is_acting_y=self.is_acting_train,
-                        mixint_type=MixIntKernelType.CONT_RELAX,
-                    )
 
             Lij, _ = cross_levels(
                 X=x, ij=ij, design_space=self.design_space, y=self.X_train


### PR DESCRIPTION
The correction was done twice for CR. Hence the GP model was not interpolating when using CR for decreed categorical variables.