### PR TITLE
Add save/load methods to GPX surrogate model

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -6,5 +6,5 @@ pyDOE3
 numpydoc
 matplotlib
 jenn >= 1.0.2, <2.0
-egobox ~= 0.20.0
+egobox ~= 0.23.0
 git+https://github.com/hwangjt/sphinx_auto_embed.git  # for doc generation 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -7,4 +7,4 @@ numpydoc
 matplotlib
 jenn >= 1.0.2, <2.0
 egobox ~= 0.23.0
-git+https://github.com/hwangjt/sphinx_auto_embed.git  # for doc generation 
+git+https://github.com/hwangjt/sphinx_auto_embed.git  # for doc generation

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ pytest-xdist    # allows running parallel testing with pytest -n <num_workers>
 pytest-cov      # allows to get coverage report
 ruff            # format and lint code
 jenn >= 1.0.2, <2.0
-egobox ~= 0.20.0
+egobox ~= 0.23.0

--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,7 @@ metadata = dict(
         "numba": [  # pip install smt[numba]
             "numba~=0.56.4",
         ],
-        "gpx": ["egobox~=0.22"],  # pip install smt[gpx]
+        "gpx": ["egobox~=0.23"],  # pip install smt[gpx]
     },
     python_requires=">=3.9",
     zip_safe=False,

--- a/smt/surrogate_models/gpx.py
+++ b/smt/surrogate_models/gpx.py
@@ -162,13 +162,29 @@ class GPX(SurrogateModel):
         Returns all variance gradients at the given x points as a [n, nx] matrix"""
         return self._gpx.predict_var_gradients(x)
 
-    def save(self, filename):
-        self._gpx.save(filename)
+    def save(self, filepath):
+        """Save the trained model in the given filepath
+
+        Arguments
+        ---------
+            filename (string): path to the json file
+        """
+        self._gpx.save(filepath)
 
     @staticmethod
-    def load(filename):
+    def load(filepath):
+        """Load the model from a previously saved GPX model.
+
+        Arguments
+        ---------
+            filename (string): path to the json file to load the model from
+
+        Returns
+        -------
+            the trained GPX model instanciation
+        """
         gpx = GPX()
-        gpx._gpx = egx.Gpx.load(filename)
+        gpx._gpx = egx.Gpx.load(filepath)
         (gpx.nx, gpx.ny) = gpx._gpx.dims()
         gpx.training_points[None][0] = gpx._gpx.training_data()
         return gpx

--- a/smt/surrogate_models/gpx.py
+++ b/smt/surrogate_models/gpx.py
@@ -161,3 +161,14 @@ class GPX(SurrogateModel):
         at n points given as [n, nx] matrix where nx is the dimension of x.
         Returns all variance gradients at the given x points as a [n, nx] matrix"""
         return self._gpx.predict_var_gradients(x)
+
+    def save(self, filename):
+        self._gpx.save(filename)
+
+    @staticmethod
+    def load(filename):
+        gpx = GPX()
+        gpx._gpx = egx.Gpx.load(filename)
+        (gpx.nx, gpx.ny) = gpx._gpx.dims()
+        gpx.training_points[None][0] = gpx._gpx.training_data()
+        return gpx

--- a/smt/surrogate_models/tests/test_gpx.py
+++ b/smt/surrogate_models/tests/test_gpx.py
@@ -51,7 +51,7 @@ class TestGPX(unittest.TestCase):
         gpx.set_training_values(xt, yt)
         gpx.train()
 
-        with tempfile.TemporaryFile(suffix=".json") as fp:
+        with tempfile.NamedTemporaryFile(suffix=".json") as fp:
             gpx.save(fp.name)
             gpx2 = GPX.load(fp.name)
 

--- a/smt/surrogate_models/tests/test_gpx.py
+++ b/smt/surrogate_models/tests/test_gpx.py
@@ -1,4 +1,5 @@
 import unittest
+import tempfile
 
 import numpy as np
 
@@ -34,6 +35,32 @@ class TestGPX(unittest.TestCase):
 
         gpx_var = gpx.predict_variances(xe)
         self.assertLessEqual(np.linalg.norm(gpx_var), 1e-3)
+
+    @unittest.skipIf(not GPX_AVAILABLE, "GPX not available")
+    def test_save_load(self):
+        ndim = 2
+        num = 20
+        problem = Sphere(ndim=ndim)
+        xlimits = problem.xlimits
+        sampling = LHS(xlimits=xlimits, criterion="ese")
+
+        xt = sampling(num)
+        yt = problem(xt)
+
+        gpx = GPX(print_global=False, seed=42)
+        gpx.set_training_values(xt, yt)
+        gpx.train()
+
+        with tempfile.TemporaryFile(suffix=".json") as fp:
+            gpx.save(fp.name)
+            gpx2 = GPX.load(fp.name)
+
+        xe = sampling(10)
+        ye = problem(xe)
+
+        gpx_y = gpx2.predict_values(xe)
+        e_error = np.linalg.norm(gpx_y - ye) / np.linalg.norm(ye)
+        self.assertLessEqual(e_error, 1e-3)
 
     @unittest.skipIf(not GPX_AVAILABLE, "GPX not available")
     def test_gpx_vs_krg(self):


### PR DESCRIPTION
This PR adds save/load capability to GPX trained surrogate model (this feature relies on `egobox 0.23`).

```python
from smt.surrogate_models import GPX

gpx = GPX(...)
gpx.set_training_values(...)
gpx.train()

# Save trained surrogate in json format
gpx.save("my_trained_gpx.json")  

# Reload the model from the saved json file
gpx2 = GPX.load("my_trained_gpx.json")
```