### PR TITLE
Refactor `smt.design_space`

### DIFF
--- a/smt/applications/tests/test_ego.py
+++ b/smt/applications/tests/test_ego.py
@@ -1120,7 +1120,7 @@ class TestEGO(SMTestCase):
             LHS, design_space, criterion="ese", random_state=random_state
         )
         Xt = sampling(n_doe)
-        if ds.HAS_CONFIG_SPACE:  # results differs wrt config_space impl
+        if ds.HAS_DESIGN_SPACE_EXT:  # results differs wrt config_space impl
             self.assertAlmostEqual(np.sum(Xt), 24.811925491708156, delta=1e-4)
         else:
             self.assertAlmostEqual(np.sum(Xt), 28.568852027679586, delta=1e-4)
@@ -1155,7 +1155,7 @@ class TestEGO(SMTestCase):
             n_start=25,
         )
         x_opt, y_opt, dnk, x_data, y_data = ego.optimize(fun=f_obj)
-        if ds.HAS_CONFIG_SPACE:  # results differs wrt config_space impl
+        if ds.HAS_DESIGN_SPACE_EXT:  # results differs wrt config_space impl
             self.assertAlmostEqual(np.sum(y_data), 8.846225704750577, delta=1e-4)
             self.assertAlmostEqual(np.sum(x_data), 41.811925504901374, delta=1e-4)
         else:

--- a/smt/applications/tests/test_mixed_integer.py
+++ b/smt/applications/tests/test_mixed_integer.py
@@ -17,9 +17,8 @@ try:
 except ImportError:
     NO_MATPLOTLIB = True
 
-import smt.design_space as ds
 from smt.design_space import (
-    HAS_CONFIG_SPACE,
+    HAS_DESIGN_SPACE_EXT,
     DesignSpace,
     CategoricalVariable,
     FloatVariable,
@@ -464,7 +463,7 @@ class TestMixedInteger(unittest.TestCase):
         self.run_mixed_gower_example()
         self.run_mixed_homo_gaussian_example()
         self.run_mixed_homo_hyp_example()
-        if ds.HAS_CONFIG_SPACE:
+        if HAS_DESIGN_SPACE_EXT:
             self.run_mixed_cs_example()
             self.run_hierarchical_design_space_example()  # works only with config space impl
 
@@ -918,7 +917,7 @@ class TestMixedInteger(unittest.TestCase):
         self._sm = sm  # to be ignored: just used for automated test
 
     @unittest.skipIf(
-        not HAS_CONFIG_SPACE, "Hierarchy ConfigSpace dependency not installed"
+        not HAS_DESIGN_SPACE_EXT, "Hierarchy ConfigSpace dependency not installed"
     )
     def test_hierarchical_design_space_example(self):
         self.run_hierarchical_design_space_example()
@@ -951,7 +950,7 @@ class TestMixedInteger(unittest.TestCase):
         )
 
     @unittest.skipIf(
-        not HAS_CONFIG_SPACE, "Hierarchy ConfigSpace dependency not installed"
+        not HAS_DESIGN_SPACE_EXT, "Hierarchy ConfigSpace dependency not installed"
     )
     def test_hierarchical_design_space_example_all_categorical_decreed(self):
         ds = DesignSpace(

--- a/smt/design_space/__init__.py
+++ b/smt/design_space/__init__.py
@@ -1,55 +1,33 @@
-import importlib
+from smt.design_space.design_space import (
+    CategoricalVariable,
+    BaseDesignSpace,
+    FloatVariable,
+    IntegerVariable,
+    OrdinalVariable,
+)
 
-spec = importlib.util.find_spec("smt_design_space")
-if spec:
+try:
+    from smt_design_space_ext import (
+        DesignSpace,
+        ensure_design_space,
+    )
+
     HAS_DESIGN_SPACE_EXT = True
-    HAS_CONFIG_SPACE = True
-    HAS_ADSG = True
-else:
+except ImportError:
+    from .design_space import (
+        DesignSpace,
+        ensure_design_space,
+    )
+
     HAS_DESIGN_SPACE_EXT = False
-    HAS_CONFIG_SPACE = False
-    HAS_ADSG = False
-
-
-if HAS_DESIGN_SPACE_EXT:
-    from smt_design_space.design_space import (
-        CategoricalVariable,
-        DesignSpace,
-        BaseDesignSpace,
-        FloatVariable,
-        IntegerVariable,
-        OrdinalVariable,
-        ensure_design_space,
-    )
-
-else:
-    from smt.design_space.design_space import (
-        CategoricalVariable,
-        DesignSpace,
-        FloatVariable,
-        IntegerVariable,
-        OrdinalVariable,
-        ensure_design_space,
-        BaseDesignSpace,
-    )
-
-if HAS_DESIGN_SPACE_EXT:
-    from smt_design_space.design_space import DesignSpaceGraph
-else:
-
-    class DesignSpaceGraph:
-        pass
-
 
 __all__ = [
-    "HAS_DESIGN_SPACE_EXT",
-    "HAS_CONFIG_SPACE",
-    "HAS_ADSG",
     "BaseDesignSpace",
-    "DesignSpace",
     "FloatVariable",
     "IntegerVariable",
     "OrdinalVariable",
     "CategoricalVariable",
+    "DesignSpace",
     "ensure_design_space",
+    "HAS_DESIGN_SPACE_EXT",
 ]

--- a/smt/design_space/design_space.py
+++ b/smt/design_space/design_space.py
@@ -9,11 +9,6 @@ from smt.sampling_methods.lhs import LHS
 from typing import List, Optional, Sequence, Tuple, Union
 
 
-HAS_DESIGN_SPACE_EXT = False
-HAS_CONFIG_SPACE = False
-HAS_ADSG = False
-
-
 class Configuration:
     pass
 

--- a/smt/design_space/tests/test_design_space.py
+++ b/smt/design_space/tests/test_design_space.py
@@ -2,7 +2,6 @@
 Author: Jasper Bussemaker <jasper.bussemaker@dlr.de>
 """
 
-import contextlib
 import itertools
 import unittest
 
@@ -11,7 +10,6 @@ import numpy as np
 from smt.sampling_methods import LHS
 
 
-import smt.design_space.design_space as ds
 from smt.design_space.design_space import (
     BaseDesignSpace,
     CategoricalVariable,
@@ -20,16 +18,6 @@ from smt.design_space.design_space import (
     OrdinalVariable,
     DesignSpace,
 )
-
-
-@contextlib.contextmanager
-def simulate_no_config_space(do_simulate=True):
-    if ds.HAS_CONFIG_SPACE and do_simulate:
-        ds.HAS_CONFIG_SPACE = False
-        yield
-        ds.HAS_CONFIG_SPACE = True
-    else:
-        yield
 
 
 class Test(unittest.TestCase):
@@ -193,8 +181,6 @@ class Test(unittest.TestCase):
 
     def test_create_design_space(self):
         DesignSpace([FloatVariable(0, 1)])
-        with simulate_no_config_space():
-            DesignSpace([FloatVariable(0, 1)])
 
     def test_design_space(self):
         ds = DesignSpace(
@@ -421,22 +407,20 @@ class Test(unittest.TestCase):
         assert len(seen_is_acting) == 2
 
     def test_check_conditionally_acting_2(self):
-        for simulate_no_cs in [True, False]:
-            with simulate_no_config_space(simulate_no_cs):
-                ds = DesignSpace(
-                    [
-                        CategoricalVariable(["A", "B", "C"]),  # x0
-                        CategoricalVariable(["E", "F"]),  # x1
-                        IntegerVariable(0, 1),  # x2
-                        FloatVariable(0, 1),  # x3
-                    ],
-                    random_state=42,
-                )
-                ds.declare_decreed_var(
-                    decreed_var=0, meta_var=1, meta_value="E"
-                )  # Activate x3 if x0 == A
+        ds = DesignSpace(
+            [
+                CategoricalVariable(["A", "B", "C"]),  # x0
+                CategoricalVariable(["E", "F"]),  # x1
+                IntegerVariable(0, 1),  # x2
+                FloatVariable(0, 1),  # x3
+            ],
+            random_state=42,
+        )
+        ds.declare_decreed_var(
+            decreed_var=0, meta_var=1, meta_value="E"
+        )  # Activate x3 if x0 == A
 
-                ds.sample_valid_x(10, random_state=42)
+        ds.sample_valid_x(10, random_state=42)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`smt` contains a standalone implementation `DesignSpace` but when the module `smt_design_space_ext` is installed it uses an enhanced implementation (based on `ConfigSpace` at the moment) allowing to manage hierarchical variables.

The constant `smt.design_space.HAS_DESIGN_SPACE_EXT` is automatically set (to `True`) when `smt_design_space_ext` is detected. It is only used for tests which results may vary depending on the design space implementation. 

Note: Normally we should not have to try to import from `smt_design_space_ext`. The `BaseDesignSpace` implementation (aka `smt.DesignSpace`, `smt_design_space_ext.DesignSpace` or `smt_design_space_ext.DesignSpaceGraph`) should be created by the user and pass to the `smt` code. This point should be addressed in an another PR later on.