### PR TITLE
Remove `smt_design_space_ext` dependency from `smt.design_space`

### DIFF
--- a/smt/applications/tests/test_ego.py
+++ b/smt/applications/tests/test_ego.py
@@ -11,7 +11,6 @@ from sys import argv
 
 import numpy as np
 
-import smt.design_space as ds
 from smt.applications import EGO
 from smt.applications.ego import Evaluator
 from smt.applications.mixed_integer import (
@@ -1120,10 +1119,7 @@ class TestEGO(SMTestCase):
             LHS, design_space, criterion="ese", random_state=random_state
         )
         Xt = sampling(n_doe)
-        if ds.HAS_DESIGN_SPACE_EXT:  # results differs wrt config_space impl
-            self.assertAlmostEqual(np.sum(Xt), 24.811925491708156, delta=1e-4)
-        else:
-            self.assertAlmostEqual(np.sum(Xt), 28.568852027679586, delta=1e-4)
+        self.assertAlmostEqual(np.sum(Xt), 28.568852027679586, delta=1e-4)
         Xt = np.array(
             [
                 [0.37454012, 1.0],
@@ -1155,12 +1151,8 @@ class TestEGO(SMTestCase):
             n_start=25,
         )
         x_opt, y_opt, dnk, x_data, y_data = ego.optimize(fun=f_obj)
-        if ds.HAS_DESIGN_SPACE_EXT:  # results differs wrt config_space impl
-            self.assertAlmostEqual(np.sum(y_data), 8.846225704750577, delta=1e-4)
-            self.assertAlmostEqual(np.sum(x_data), 41.811925504901374, delta=1e-4)
-        else:
-            self.assertAlmostEqual(np.sum(y_data), 7.8471910288712, delta=1e-4)
-            self.assertAlmostEqual(np.sum(x_data), 34.81192549, delta=1e-4)
+        self.assertAlmostEqual(np.sum(y_data), 7.8471910288712, delta=1e-4)
+        self.assertAlmostEqual(np.sum(x_data), 34.81192549, delta=1e-4)
 
     def test_ego_gek(self):
         ego, fun = self.initialize_ego_gek()
@@ -1237,7 +1229,7 @@ class TestEGO(SMTestCase):
 
         from smt.applications import EGO
         from smt.surrogate_models import KRG
-        from smt.utils.design_space import DesignSpace
+        from smt.design_space import DesignSpace
 
         def function_test_1d(x):
             # function xsinx
@@ -1328,7 +1320,7 @@ class TestEGO(SMTestCase):
         from smt.applications import EGO
         from smt.applications.mixed_integer import MixedIntegerContext
         from smt.surrogate_models import KRG, MixIntKernelType
-        from smt.utils.design_space import (
+        from smt.design_space import (
             CategoricalVariable,
             DesignSpace,
             FloatVariable,

--- a/smt/applications/tests/test_mixed_integer.py
+++ b/smt/applications/tests/test_mixed_integer.py
@@ -462,6 +462,11 @@ class TestMixedInteger(unittest.TestCase):
         self.run_mixed_gower_example()
         self.run_mixed_homo_gaussian_example()
         self.run_mixed_homo_hyp_example()
+        # FIXME: this test should belong to smt_design_space_ext
+        # but at the moment run_* code is used here to generate doc here in smt
+        # if HAS_DESIGN_SPACE_EXT:
+        #     self.run_mixed_cs_example()
+        #     self.run_hierarchical_design_space_example()  # works only with config space impl
 
     def run_mixed_integer_lhs_example(self):
         import matplotlib.pyplot as plt
@@ -2124,6 +2129,7 @@ class TestMixedInteger(unittest.TestCase):
         plt.tight_layout()
         plt.show()
 
+    # FIXME: Used in SMT documentation but belongs to smt_design_space_ext domain
     def run_mixed_cs_example(self):
         import matplotlib.pyplot as plt
         import numpy as np
@@ -2255,6 +2261,7 @@ class TestMixedInteger(unittest.TestCase):
         plt.tight_layout()
         plt.show()
 
+    # FIXME: Used in SMT documentation but belongs to smt_design_space_ext domain
     def run_mixed_homo_gaussian_example(self):
         import matplotlib.pyplot as plt
         import numpy as np

--- a/smt/applications/tests/test_mixed_integer.py
+++ b/smt/applications/tests/test_mixed_integer.py
@@ -18,7 +18,6 @@ except ImportError:
     NO_MATPLOTLIB = True
 
 from smt.design_space import (
-    HAS_DESIGN_SPACE_EXT,
     DesignSpace,
     CategoricalVariable,
     FloatVariable,
@@ -463,9 +462,6 @@ class TestMixedInteger(unittest.TestCase):
         self.run_mixed_gower_example()
         self.run_mixed_homo_gaussian_example()
         self.run_mixed_homo_hyp_example()
-        if HAS_DESIGN_SPACE_EXT:
-            self.run_mixed_cs_example()
-            self.run_hierarchical_design_space_example()  # works only with config space impl
 
     def run_mixed_integer_lhs_example(self):
         import matplotlib.pyplot as plt
@@ -916,8 +912,8 @@ class TestMixedInteger(unittest.TestCase):
 
         self._sm = sm  # to be ignored: just used for automated test
 
-    @unittest.skipIf(
-        not HAS_DESIGN_SPACE_EXT, "Hierarchy ConfigSpace dependency not installed"
+    @unittest.skip(
+        "Use smt design space extension capability, this test should be moved in smt_design_space_ext"
     )
     def test_hierarchical_design_space_example(self):
         self.run_hierarchical_design_space_example()
@@ -949,8 +945,8 @@ class TestMixedInteger(unittest.TestCase):
             > 1e-8
         )
 
-    @unittest.skipIf(
-        not HAS_DESIGN_SPACE_EXT, "Hierarchy ConfigSpace dependency not installed"
+    @unittest.skip(
+        "Use smt design space extension capability, this test should be moved in smt_design_space_ext"
     )
     def test_hierarchical_design_space_example_all_categorical_decreed(self):
         ds = DesignSpace(

--- a/smt/design_space/__init__.py
+++ b/smt/design_space/__init__.py
@@ -4,22 +4,9 @@ from smt.design_space.design_space import (
     FloatVariable,
     IntegerVariable,
     OrdinalVariable,
+    DesignSpace,
+    ensure_design_space,
 )
-
-try:
-    from smt_design_space_ext import (
-        DesignSpace,
-        ensure_design_space,
-    )
-
-    HAS_DESIGN_SPACE_EXT = True
-except ImportError:
-    from .design_space import (
-        DesignSpace,
-        ensure_design_space,
-    )
-
-    HAS_DESIGN_SPACE_EXT = False
 
 __all__ = [
     "BaseDesignSpace",


### PR DESCRIPTION
Some are skipped in mixed_integer and should be transfered in `smt_design_space_ext`.
Some examples scripts are kept here as documentation is generated under smt though it uses advanced features from `smt_design_space_ext`
