### PR TITLE
Fix to LHS ese comparison

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -28,6 +28,7 @@ SMT has been developed thanks to contributions from:
 * Maël Tremouille
 * Mauricio Castano Aguirre
 * Mostafa Meliani
+* Neal Kesterton
 * Nick Thompson
 * Nicolas Gonel
 * Nina Moëllo

--- a/smt/applications/tests/test_ego.py
+++ b/smt/applications/tests/test_ego.py
@@ -1119,7 +1119,7 @@ class TestEGO(SMTestCase):
             LHS, design_space, criterion="ese", random_state=random_state
         )
         Xt = sampling(n_doe)
-        self.assertAlmostEqual(np.sum(Xt), 28.568852027679586, delta=1e-4)
+        self.assertAlmostEqual(np.sum(Xt), 33.56885202767958, delta=1e-4)
         Xt = np.array(
             [
                 [0.37454012, 1.0],
@@ -1151,8 +1151,8 @@ class TestEGO(SMTestCase):
             n_start=25,
         )
         x_opt, y_opt, dnk, x_data, y_data = ego.optimize(fun=f_obj)
-        self.assertAlmostEqual(np.sum(y_data), 7.8471910288712, delta=1e-4)
-        self.assertAlmostEqual(np.sum(x_data), 34.81192549, delta=1e-4)
+        self.assertAlmostEqual(np.sum(y_data), 8.846225742003778, delta=1e-4)
+        self.assertAlmostEqual(np.sum(x_data), 41.81192549000013, delta=1e-4)
 
     def test_ego_gek(self):
         ego, fun = self.initialize_ego_gek()

--- a/smt/sampling_methods/lhs.py
+++ b/smt/sampling_methods/lhs.py
@@ -211,7 +211,7 @@ class LHS(ScaledSamplingMethod):
             hist_T.extend(inner_loop * [T])
             hist_proba.extend(inner_loop * [p_accpt])
 
-            if PhiP_best - PhiP_oldbest < tol:
+            if PhiP_oldbest - PhiP_best > tol:
                 # flag_imp = 1
                 if p_accpt >= 0.1 and p_imp < p_accpt:
                     T = 0.8 * T


### PR DESCRIPTION
Fix for issue #682 

- Updates comparison in LHS ese algorithm to allow it go into exploration mode
- Updates failed test cases which rely on the ese algorithm results