### PR TITLE
Add a warning on kriging-based surrogates being trained with multiple outputs

### DIFF
--- a/smt/surrogate_models/krg_based.py
+++ b/smt/surrogate_models/krg_based.py
@@ -310,9 +310,10 @@ class KrgBased(SurrogateModel):
         if self.ny > 1:
             warnings.warn(
                 "Kriging-based surrogate is not intended to handle multiple "
-                f"training output data (found yt dim = {self.ny}). "
+                f"training output data (yt dim should be 1, got {self.ny}). "
                 "The quality of the resulting surrogate might not be as good as "
-                "if each training output is used separately to build a dedicated surrogate"
+                "if each training output is used separately to build a dedicated surrogate. "
+                "This warning might become a hard error in future SMT versions."
             )
         if is_acting is not None:
             self.is_acting_points[name] = is_acting

--- a/smt/surrogate_models/krg_based.py
+++ b/smt/surrogate_models/krg_based.py
@@ -307,6 +307,13 @@ class KrgBased(SurrogateModel):
             Matrix specifying which of the design variables is acting in a hierarchical design space
         """
         super().set_training_values(xt, yt, name=name)
+        if self.ny > 1:
+            warnings.warn(
+                "Kriging-based surrogate is not intended to handle multiple "
+                f"training output data (found yt dim = {self.ny}). "
+                "The quality of the resulting surrogate might not be as good as "
+                "if each training output is used separately to build a dedicated surrogate"
+            )
         if is_acting is not None:
             self.is_acting_points[name] = is_acting
 
@@ -397,6 +404,7 @@ class KrgBased(SurrogateModel):
         # Sampling points X and y
         X = self.training_points[None][0][0]
         y = self.training_points[None][0][1]
+
         # Get is_acting status from design space model if needed (might correct training points)
         is_acting = self.is_acting_points.get(None)
         if is_acting is None and not self.is_continuous:

--- a/smt/surrogate_models/tests/test_krg_based.py
+++ b/smt/surrogate_models/tests/test_krg_based.py
@@ -40,6 +40,11 @@ class TestKrgBased(unittest.TestCase):
         krg.set_training_values(np.array([[1, 2, 3]]), np.array([[1]]))  # erroneous
         self.assertRaises(ValueError, krg._check_param)
 
+    def test_multiple_training_outputs_warning(self):
+        krg = KrgBased()
+        with self.assertWarns(UserWarning):
+            krg.set_training_values(np.array([[1, 2, 3]]), np.array([[1, 1]]))
+
     def test_less_almost_squar_exp(self):
         nobs = 50  # number of obsertvations
         np.random.seed(0)  # a seed for reproducibility


### PR DESCRIPTION
The surrogate API of SMT allows to pass several training data outputs as some surrogates are able to handle them. Currently kriging-based models happen to swallow such data and provide a surrogate but this resulting surrogate might not be as good as if we train a dedicated surrogate for each output (as only one set of hyperameters is actually optimized, the detailed impact of multiple outputs still has to be investigated).

As it was reported though with multiple outputs the resulting surrogate could be "good enough", this PR just adds a warning when `set_training_values()` is used with multiple outputs. Still such usage is not currently recommended (at least without checking the surrogate quality properly) and this warning might become a hard error in the future. 

This PR relates to #679