### PR TITLE
Handle scipy 1.15 changes related to `derivative` function used in benchmarking problems

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,5 @@
 Cython
+packaging
 numpy
 scipy
 scikit-learn

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 Cython
+packaging
 numpy
-scipy < 1.15
+scipy
 scikit-learn
 pyDOE3
 numba           # JIT compiler

--- a/setup.py
+++ b/setup.py
@@ -112,6 +112,7 @@ metadata = dict(
         "smt.kernels",
     ],
     install_requires=[
+        "packaging",
         "scikit-learn",
         "pyDOE3",
         "scipy",

--- a/smt/problems/torsion_vibration.py
+++ b/smt/problems/torsion_vibration.py
@@ -16,7 +16,7 @@ and materials conference, Newport, RI, pp. AIAA 2006-1811.
 """
 
 import numpy as np
-from scipy.misc import derivative
+from smt.utils.misc import SCIPY_DERIVATIVE
 
 from smt.problems.problem import Problem
 
@@ -91,7 +91,7 @@ class TorsionVibration(Problem):
                 args[var] = x
                 return func(*args)
 
-            return derivative(wraps, point[var], dx=1e-6)
+            return SCIPY_DERIVATIVE(wraps, point[var], dx=1e-6)
 
         def func(x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14):
             K1 = np.pi * x2 * x0 / (32 * x1)

--- a/smt/problems/water_flow.py
+++ b/smt/problems/water_flow.py
@@ -14,7 +14,7 @@ Use of Derivatives in Surface Prediction. Technometrics, 35(3), pp. 243-255. 199
 """
 
 import numpy as np
-from scipy.misc import derivative
+from smt.utils.misc import SCIPY_DERIVATIVE
 
 from smt.problems.problem import Problem
 
@@ -57,7 +57,7 @@ class WaterFlow(Problem):
                 args[var] = x
                 return func(*args)
 
-            return derivative(wraps, point[var], dx=1e-6)
+            return SCIPY_DERIVATIVE(wraps, point[var], dx=1e-6)
 
         def func(x0, x1, x2, x3, x4, x5, x6, x7):
             return (

--- a/smt/problems/water_flow_lfidelity.py
+++ b/smt/problems/water_flow_lfidelity.py
@@ -8,7 +8,7 @@ and low-accuracy computer codes. Technometrics, 55(1), 37-46.
 """
 
 import numpy as np
-from scipy.misc import derivative
+from smt.utils.misc import SCIPY_DERIVATIVE
 
 from smt.problems.problem import Problem
 
@@ -51,7 +51,7 @@ class WaterFlowLFidelity(Problem):
                 args[var] = x
                 return func(*args)
 
-            return derivative(wraps, point[var], dx=1e-6)
+            return SCIPY_DERIVATIVE(wraps, point[var], dx=1e-6)
 
         def func(x0, x1, x2, x3, x4, x5, x6, x7):
             return (

--- a/smt/problems/welded_beam.py
+++ b/smt/problems/welded_beam.py
@@ -14,7 +14,7 @@ Computer methods in applied mechanics and engineering, 186(2), pp. 311-338. 2000
 """
 
 import numpy as np
-from scipy.misc import derivative
+from smt.utils.misc import SCIPY_DERIVATIVE
 
 from smt.problems.problem import Problem
 
@@ -55,7 +55,7 @@ class WeldedBeam(Problem):
                 args[var] = x
                 return func(*args)
 
-            return derivative(wraps, point[var], dx=1e-6)
+            return SCIPY_DERIVATIVE(wraps, point[var], dx=1e-6)
 
         def func(x0, x1, x2):
             tau1 = 6000 / (np.sqrt(2) * x1 * x2)

--- a/smt/problems/wing_weight.py
+++ b/smt/problems/wing_weight.py
@@ -14,7 +14,7 @@ Engineering Design Via Surrogate Modelling: A Practical Guide, John Wiley & Sons
 """
 
 import numpy as np
-from scipy.misc import derivative
+from smt.utils.misc import SCIPY_DERIVATIVE
 
 from smt.problems.problem import Problem
 
@@ -61,7 +61,7 @@ class WingWeight(Problem):
                 args[var] = x
                 return func(*args)
 
-            return derivative(wraps, point[var], dx=1e-6)
+            return SCIPY_DERIVATIVE(wraps, point[var], dx=1e-6)
 
         def func(x0, x1, x2, x3, x4, x5, x6, x7, x8, x9):
             return (

--- a/smt/utils/misc.py
+++ b/smt/utils/misc.py
@@ -13,8 +13,8 @@ import scipy
 from packaging.version import Version
 
 # Since scipy 1.15, derivative function has moved from scipy.misc to scipy.differentiate
-# As derivative is used by several benchmark problems, we initialize a constant
-# once here as a proxy of the derivative function wrt scipy version installed
+# As derivative is used by several benchmarking problems, we initialize a constant
+# once here as a proxy of the derivative function wrt the installed scipy version
 if Version(scipy.__version__) >= Version("1.15"):
     SCIPY_DERIVATIVE = scipy.differentiate.derivative
 else:

--- a/smt/utils/misc.py
+++ b/smt/utils/misc.py
@@ -9,6 +9,17 @@ from bisect import bisect_left
 
 import numpy as np
 
+import scipy
+from packaging.version import Version
+
+# Since scipy 1.15, derivative function has moved from scipy.misc to scipy.differentiate
+# As derivative is used by several benchmark problems, we initialize a constant
+# once here as a proxy of the derivative function wrt scipy version installed
+if Version(scipy.__version__) >= Version("1.15"):
+    SCIPY_DERIVATIVE = scipy.differentiate.derivative
+else:
+    SCIPY_DERIVATIVE = scipy.misc.derivative
+
 
 def standardization(X, y):
     """


### PR DESCRIPTION
Since scipy 1.15, `derivative` function has been moved from `scipy.misc` to `scipy.differentiate`

Fixes #706 