### PR TITLE
Add pre-commit hook for ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  # Ruff version.
+  rev: v0.8.6
+  hooks:
+    # Run the linter.
+    - id: ruff
+    # Run the formatter.
+    - id: ruff-format


### PR DESCRIPTION
Add ruff linting and formatting configuration for pre-commit.

Basically, if pre-commit is not already installed, you have to:

1. `pip install pre-commit`
2. `pre-commit install`

then ruff linting and formatting will run automatically on commit.

See [pre-commit quickstart](https://pre-commit.com/#quick-start).

