### PR TITLE
Allow to disable hyperparameter optimization in kriging-based surrogates

### DIFF
--- a/smt/surrogate_models/krg_based.py
+++ b/smt/surrogate_models/krg_based.py
@@ -153,9 +153,8 @@ class KrgBased(SurrogateModel):
         declare(
             "hyper_opt",
             "TNC",
-            values=("Cobyla", "TNC"),
+            values=("Cobyla", "TNC", "NoOp"),
             desc="Optimiser for hyperparameters optimisation",
-            types=str,
         )
         declare(
             "eval_noise",
@@ -2267,10 +2266,12 @@ class KrgBased(SurrogateModel):
                             )
                             if optimal_theta_res_loop["fun"] < optimal_theta_res["fun"]:
                                 optimal_theta_res = optimal_theta_res_loop
+                    elif self.options["hyper_opt"] == "NoOp":
+                        optimal_theta_res["x"] = theta0
 
                     if "x" not in optimal_theta_res:
                         raise ValueError(
-                            f"Optimizer encountered a problem: {optimal_theta_res_loop!s}"
+                            f"Optimizer encountered a problem: {optimal_theta_res_loop}"
                         )
                     optimal_theta = optimal_theta_res["x"]
 

--- a/smt/surrogate_models/tests/test_krg_predictions.py
+++ b/smt/surrogate_models/tests/test_krg_predictions.py
@@ -206,6 +206,18 @@ class Test(SMTestCase):
         )
         np.testing.assert_allclose(total_error, 0, atol=1e-9)
 
+    def test_fixed_theta(self):
+        theta0 = np.ones(2)
+
+        sm = KRG(theta0=theta0)
+        sm.set_training_values(self.xt, self.yt)
+        sm.train()
+        print(sm.optimal_theta)  # [0.04373813 0.00697964]
+        sm = KRG(theta0=theta0, hyper_opt="NoOp")
+        sm.set_training_values(self.xt, self.yt)
+        sm.train()
+        np.testing.assert_allclose(sm.optimal_theta, theta0, 1e-2)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR adds a "NoOp" value to the `hyper_opt` option of kriging-based surrogates, meaning there is actually no optimization done and the given theta0 value is used as the optimal hyperparameter value.

This setting is useful when the user wants to use predict methods with a given theta setting and avoiding the cost of the optimization.