### PR TITLE
Support egobox 0.32

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ metadata = dict(
         "numba": [  # pip install smt[numba]
             "numba~=0.56.4",
         ],
-        "gpx": ["egobox~=0.31"],  # pip install smt[gpx]
+        "gpx": ["egobox~=0.32"],  # pip install smt[gpx]
     },
     python_requires=">=3.9",
     zip_safe=False,

--- a/smt/surrogate_models/gpx.py
+++ b/smt/surrogate_models/gpx.py
@@ -137,10 +137,10 @@ class GPX(SurrogateModel):
         self._gpx = egx.Gpx.builder(**config).fit(xt, yt)
 
     def _predict_values(self, x):
-        return self._gpx.predict(x)
+        return self._gpx.predict(x).reshape(-1, 1)
 
     def _predict_variances(self, x):
-        return self._gpx.predict_var(x)
+        return self._gpx.predict_var(x).reshape(-1, 1)
 
     def _predict_derivatives(self, x, kx):
         return self._gpx.predict_gradients(x)[:, kx : kx + 1]


### PR DESCRIPTION
This PR takes into account return type change of `egobox::Gpx::predict()` and `egobox::Gpx::predict_var()` from array(n, 1) to array(n,) 