### PR TITLE
Make `options` readonly in `KrgBased` surrogates 

### DIFF
--- a/smt/applications/cckrg.py
+++ b/smt/applications/cckrg.py
@@ -163,7 +163,7 @@ class CoopCompKRG(KrgBased):
             dx,
             self.options["corr"],
             self.nx,
-            self.options["pow_exp_power"],
+            self._pow_exp_power,
             theta=theta,
             return_derivative=return_derivative,
         )

--- a/smt/applications/cckrg.py
+++ b/smt/applications/cckrg.py
@@ -188,7 +188,7 @@ class CoopCompKRG(KrgBased):
         try:
             self.coop_theta = self.optimal_theta
         except AttributeError:
-            self.coop_theta = self.options["theta0"] * np.ones((self.nx))
+            self.coop_theta = self._theta0 * np.ones((self.nx))
 
         # Hyperparameter optimization for active components
         self.active_comp_var = self.comp_var[active_coop_comp]

--- a/smt/applications/mfck.py
+++ b/smt/applications/mfck.py
@@ -114,7 +114,7 @@ class MFCK(KrgBased):
             # For a single level, initialize theta_ini, lower_bounds, and
             # upper_bounds with consistent shapes
             theta_ini = np.hstack(
-                (self.options["sigma0"], self.options["theta0"])
+                (self.options["sigma0"], self._theta0)
             )  # Variance + initial theta values
             lower_bounds = np.hstack(
                 (
@@ -129,7 +129,7 @@ class MFCK(KrgBased):
                 )
             )
             # Apply log10 to theta_ini and bounds
-            nb_params = len(self.options["theta0"])
+            nb_params = len(self._theta0)
             theta_ini[: nb_params + 1] = np.log10(theta_ini[: nb_params + 1])
             lower_bounds[: nb_params + 1] = np.log10(lower_bounds[: nb_params + 1])
             upper_bounds[: nb_params + 1] = np.log10(upper_bounds[: nb_params + 1])
@@ -138,7 +138,7 @@ class MFCK(KrgBased):
                 if lvl == 0:
                     # Initialize theta_ini for level 0
                     theta_ini = np.hstack(
-                        (self.options["sigma0"], self.options["theta0"])
+                        (self.options["sigma0"], self._theta0)
                     )  # Variance + initial theta values
                     lower_bounds = np.hstack(
                         (
@@ -153,7 +153,7 @@ class MFCK(KrgBased):
                         )
                     )
                     # Apply log10 to theta_ini and bounds
-                    nb_params = len(self.options["theta0"])
+                    nb_params = len(self._theta0)
                     theta_ini[: nb_params + 1] = np.log10(theta_ini[: nb_params + 1])
                     lower_bounds[: nb_params + 1] = np.log10(
                         lower_bounds[: nb_params + 1]
@@ -164,7 +164,7 @@ class MFCK(KrgBased):
 
                 elif lvl > 0:
                     # For additional levels, append to theta_ini, lower_bounds, and upper_bounds
-                    thetat = np.hstack((self.options["sigma0"], self.options["theta0"]))
+                    thetat = np.hstack((self.options["sigma0"], self._theta0))
                     lower_boundst = np.hstack(
                         (
                             self.options["sigma_bounds"][0],

--- a/smt/applications/mfk.py
+++ b/smt/applications/mfk.py
@@ -284,12 +284,12 @@ class MFK(KrgBased):
             self._mix_int_corr.reset()
 
         self._new_train_init()
-        theta0 = self.options["theta0"].copy()
+        theta0 = self._theta0.copy()
         noise0 = self.options["noise0"].copy()
 
         for lvl in range(self.nlvl):
             self._new_train_iteration(lvl)
-            self.options["theta0"] = theta0
+            self._theta0 = theta0
             self.options["noise0"] = noise0
 
         self._reinterpolate(lvl)
@@ -381,7 +381,7 @@ class MFK(KrgBased):
     def _new_train_iteration(self, lvl):
         n_samples = self.nt_all
         self.options["noise0"] = np.array([self.options["noise0"][lvl]]).flatten()
-        self.options["theta0"] = self.options["theta0"][lvl, :]
+        self._theta0 = list(self._theta0[lvl, :])
 
         self.X_norma = self.X_norma_all[lvl]
         self.y_norma = self.y_norma_all[lvl]
@@ -1069,29 +1069,29 @@ class MFK(KrgBased):
                     "Only the continuous relaxation kernel is available with multi-fidelity"
                 )
 
-        if isinstance(self.options["theta0"], np.ndarray):
-            if self.options["theta0"].shape != (self.nlvl, n_param):
+        if isinstance(self._theta0, np.ndarray):
+            if self._theta0.shape != (self.nlvl, n_param):
                 raise ValueError(
                     "the dimensions of theta0 %s should coincide to the number of dim %s"
-                    % (self.options["theta0"].shape, (self.nlvl, n_param))
+                    % (self._theta0.shape, (self.nlvl, n_param))
                 )
         else:
-            if len(self.options["theta0"]) != n_param:
-                if len(self.options["theta0"]) == 1:
-                    self.options["theta0"] *= np.ones((self.nlvl, n_param))
-                elif len(self.options["theta0"]) == self.nlvl:
-                    self.options["theta0"] = np.array(self.options["theta0"]).reshape(
-                        -1, 1
+            if len(self._theta0) != n_param:
+                if len(self._theta0) == 1:
+                    self._theta0 = np.array(self._theta0) * np.ones(
+                        (self.nlvl, n_param)
                     )
-                    self.options["theta0"] *= np.ones((1, n_param))
+                elif len(self._theta0) == self.nlvl:
+                    self._theta0 = np.array(self._theta0).reshape(-1, 1)
+                    self._theta0 = self._theta0 * np.ones((1, n_param))
                 else:
                     raise ValueError(
                         "the length of theta0 (%s) should be equal to the number of dim (%s) \
                             or levels of fidelity (%s)."
-                        % (len(self.options["theta0"]), n_param, self.nlvl)
+                        % (len(self._theta0), n_param, self.nlvl)
                     )
             else:
-                self.options["theta0"] *= np.ones((self.nlvl, 1))
+                self._theta0 = np.array(self._theta0) * np.ones((self.nlvl, 1))
 
         if len(self.options["noise0"]) != self.nlvl:
             if len(self.options["noise0"]) == 1:

--- a/smt/applications/mfk.py
+++ b/smt/applications/mfk.py
@@ -285,12 +285,12 @@ class MFK(KrgBased):
 
         self._new_train_init()
         theta0 = self._theta0.copy()
-        noise0 = self.options["noise0"].copy()
+        noise0 = deepcopy(self._noise0)
 
         for lvl in range(self.nlvl):
             self._new_train_iteration(lvl)
             self._theta0 = theta0
-            self.options["noise0"] = noise0
+            self._noise0 = noise0
 
         self._reinterpolate(lvl)
 
@@ -380,13 +380,13 @@ class MFK(KrgBased):
 
     def _new_train_iteration(self, lvl):
         n_samples = self.nt_all
-        self.options["noise0"] = np.array([self.options["noise0"][lvl]]).flatten()
+        self._noise0 = np.array([self._noise0[lvl]]).flatten()
         self._theta0 = list(self._theta0[lvl, :])
 
         self.X_norma = self.X_norma_all[lvl]
         self.y_norma = self.y_norma_all[lvl]
 
-        if self.options["eval_noise"]:
+        if self._eval_noise:
             if self.options["use_het_noise"]:
                 # hetGP works with unique design variables
                 (
@@ -405,7 +405,7 @@ class MFK(KrgBased):
                 y_norma_unique = np.array(y_norma_unique).reshape(-1, 1)
 
                 # pointwise sensible estimates of the noise variances (see Ankenman et al., 2010)
-                self.optimal_noise = self.options["noise0"] * np.ones(self.nt_all[lvl])
+                self.optimal_noise = self._noise0 * np.ones(self.nt_all[lvl])
                 for i in range(self.nt_all[lvl]):
                     diff = self.y_norma[self.index_unique == i] - y_norma_unique[i]
                     if np.sum(diff**2) != 0.0:
@@ -417,7 +417,7 @@ class MFK(KrgBased):
                 self.X_norma_all[lvl] = self.X_norma
                 self.y_norma_all[lvl] = self.y_norma
         else:
-            self.optimal_noise = self.options["noise0"] / self.y_std**2
+            self.optimal_noise = self._noise0 / self.y_std**2
             self.optimal_noise_all[lvl] = self.optimal_noise
 
         # Calculate matrix of distances D between samples
@@ -507,7 +507,7 @@ class MFK(KrgBased):
             self.optimal_par[lvl],
             self.optimal_theta[lvl],
         ) = self._run_optimization(D)
-        if self.options["eval_noise"] and not self.options["use_het_noise"]:
+        if self._eval_noise and not self.options["use_het_noise"]:
             tmp_list = self.optimal_theta[lvl]
             self.optimal_theta[lvl] = tmp_list[:-1]
             self.optimal_noise = tmp_list[-1]
@@ -515,7 +515,7 @@ class MFK(KrgBased):
         del self.y_norma, self.D, self.optimal_noise
 
     def _reinterpolate(self, lvl):
-        if self.options["eval_noise"] and self.options["optim_var"]:
+        if self._eval_noise and self.options["optim_var"]:
             X = self.X
             for lvl in range(self.nlvl - 1):
                 self.set_training_values(
@@ -524,13 +524,13 @@ class MFK(KrgBased):
             self.set_training_values(
                 X[-1], self._predict_intermediate_values(X[-1], self.nlvl)
             )
-            self.options["eval_noise"] = False
+            self._eval_noise_request = False
             self._new_train()
-            self.options["eval_noise"] = True
+            del self._eval_noise_request
 
     def _componentwise_distance(self, dx):
         d = componentwise_distance(
-            dx, self.options["corr"], self.nx, power=self.options["pow_exp_power"]
+            dx, self.options["corr"], self.nx, power=self._pow_exp_power
         )
         return d
 
@@ -1018,6 +1018,15 @@ class MFK(KrgBased):
         Overrides KrgBased implementation
         This function checks some parameters of the model.
         """
+        from copy import deepcopy
+
+        # Create working copies of mutable options to avoid mutating self.options
+        self._theta0 = list(self.options["theta0"])
+        self._eval_noise = getattr(
+            self, "_eval_noise_request", self.options["eval_noise"]
+        )
+        self._noise0 = deepcopy(self.options["noise0"])
+        self._hyper_opt = self.options["hyper_opt"]
 
         if self._use_pls:
             d = self.options["n_comp"]
@@ -1038,11 +1047,9 @@ class MFK(KrgBased):
                     "MFKPLSK only works with a squared exponential kernel (until we prove the contrary)"
                 )
         # noise0 may be a list of noise values for various fi levels with various length
-        max_noise = np.max([np.max(row) for row in self.options["noise0"]])
-        if (self.options["eval_noise"] or max_noise > 1e-12) and self.options[
-            "hyper_opt"
-        ] == "TNC":
-            self.options["hyper_opt"] = "Cobyla"
+        max_noise = np.max([np.max(row) for row in self._noise0])
+        if (self._eval_noise or max_noise > 1e-12) and self._hyper_opt == "TNC":
+            self._hyper_opt = "Cobyla"
             warnings.warn(
                 "TNC not available yet for noise handling. Switching to Cobyla"
             )
@@ -1093,30 +1100,30 @@ class MFK(KrgBased):
             else:
                 self._theta0 = np.array(self._theta0) * np.ones((self.nlvl, 1))
 
-        if len(self.options["noise0"]) != self.nlvl:
-            if len(self.options["noise0"]) == 1:
-                self.options["noise0"] = self.nlvl * [self.options["noise0"]]
+        if len(self._noise0) != self.nlvl:
+            if len(self._noise0) == 1:
+                self._noise0 = self.nlvl * [self._noise0]
             else:
                 raise ValueError(
                     "the length of noise0 (%s) should be equal to the number of levels of fidelity (%s)."
-                    % (len(self.options["noise0"]), self.nlvl)
+                    % (len(self._noise0), self.nlvl)
                 )
 
         for i in range(self.nlvl):
             if self.options["use_het_noise"]:
                 if len(self.X[i]) == len(np.unique(self.X[i])):
-                    if len(self.options["noise0"][i]) != self.nt_all[i]:
-                        if len(self.options["noise0"][i]) == 1:
-                            self.options["noise0"][i] *= np.ones(self.nt_all[i])
+                    if len(self._noise0[i]) != self.nt_all[i]:
+                        if len(self._noise0[i]) == 1:
+                            self._noise0[i] *= np.ones(self.nt_all[i])
                         else:
                             raise ValueError(
                                 "for the level of fidelity %s, the length of noise0 (%s) should be equal to \
                                     the number of observations (%s)."
-                                % (i, len(self.options["noise0"][i]), self.nt_all[i])
+                                % (i, len(self._noise0[i]), self.nt_all[i])
                             )
             else:
-                if np.size(self.options["noise0"][i]) != 1:
+                if np.size(self._noise0[i]) != 1:
                     raise ValueError(
                         "for the level of fidelity %s, the length of noise0 (%s) should be equal to one."
-                        % (i, len(self.options["noise0"][i]))
+                        % (i, len(self._noise0[i]))
                     )

--- a/smt/applications/mfkpls.py
+++ b/smt/applications/mfkpls.py
@@ -63,7 +63,7 @@ class MFKPLS(MFK):
             self.options["corr"],
             self.options["n_comp"],
             self.coeff_pls,
-            power=self.options["pow_exp_power"],
+            power=self._pow_exp_power,
         )
         return d
 

--- a/smt/applications/mfkplsk.py
+++ b/smt/applications/mfkplsk.py
@@ -75,9 +75,9 @@ class MFKPLSK(MFKPLS):
             theta = best_theta
 
         if self.options["corr"] == "squar_exp":
-            self.options["theta0"] = (theta * self.coeff_pls**2).sum(1)
+            self._theta0 = list((theta * self.coeff_pls**2).sum(1))
         else:
-            self.options["theta0"] = (theta * np.abs(self.coeff_pls)).sum(1)
+            self._theta0 = list((theta * np.abs(self.coeff_pls)).sum(1))
         self.n_param = compute_n_param(
             self.design_space,
             self.options["categorical_kernel"],
@@ -104,13 +104,13 @@ class MFKPLSK(MFKPLS):
         """
         self._new_train_init()
         self.n_comp = self.options["n_comp"]
-        theta0 = self.options["theta0"].copy()
+        theta0 = self._theta0.copy()
         noise0 = self.options["noise0"].copy()
 
         for lvl in range(self.nlvl):
             self._new_train_iteration(lvl)
             self.options["n_comp"] = self.n_comp
-            self.options["theta0"] = theta0
+            self._theta0 = theta0
             self.options["noise0"] = noise0
 
         self._reinterpolate(lvl)

--- a/smt/applications/mfkplsk.py
+++ b/smt/applications/mfkplsk.py
@@ -11,6 +11,7 @@ Adapted on January 2021 by Andres Lopez-Lopera to the new SMT version
 """
 
 import numpy as np
+from copy import deepcopy
 
 from smt.applications import MFKPLS
 from smt.surrogate_models.krg_based import compute_n_param
@@ -50,7 +51,7 @@ class MFKPLSK(MFKPLS):
         else:
             # Full Kriging step (prediction and second optimization pass)
             d = componentwise_distance(
-                dx, self.options["corr"], self.nx, power=self.options["pow_exp_power"]
+                dx, self.options["corr"], self.nx, power=self._pow_exp_power
             )
         return d
 
@@ -69,7 +70,7 @@ class MFKPLSK(MFKPLS):
         _, _, best_theta = self._optimize_hyperparam(D)
 
         # Project PLS theta back to full Kriging space
-        if self.options["eval_noise"]:
+        if self._eval_noise:
             theta = best_theta[:-1]
         else:
             theta = best_theta
@@ -85,7 +86,7 @@ class MFKPLSK(MFKPLS):
             None,
             None,
         )
-        self.options["n_comp"] = int(self.n_param)
+        self._n_comp = int(self.n_param)
         self.best_iteration_fail = None
 
         # Second pass: optimize in full Kriging space (no multistart)
@@ -94,7 +95,7 @@ class MFKPLSK(MFKPLS):
         return self._optimize_hyperparam(
             D,
             use_multistart=False,
-            limit=10 * self.options["n_comp"],
+            limit=10 * self._n_comp,
         )
 
     def _new_train(self):
@@ -103,15 +104,13 @@ class MFKPLSK(MFKPLS):
         Trains the Multi-Fidelity model + PLS (done on the highest fidelity level) + Kriging  (MFKPLSK)
         """
         self._new_train_init()
-        self.n_comp = self.options["n_comp"]
         theta0 = self._theta0.copy()
-        noise0 = self.options["noise0"].copy()
+        noise0 = deepcopy(self._noise0)
 
         for lvl in range(self.nlvl):
             self._new_train_iteration(lvl)
-            self.options["n_comp"] = self.n_comp
             self._theta0 = theta0
-            self.options["noise0"] = noise0
+            self._noise0 = noise0
 
         self._reinterpolate(lvl)
 

--- a/smt/applications/smfk.py
+++ b/smt/applications/smfk.py
@@ -59,13 +59,13 @@ class SMFK(MFK):
 
     def _new_train_iteration(self, lvl):
         # n_samples = self.nt_all
-        self.options["noise0"] = np.array([self.options["noise0"][lvl]]).flatten()
+        self._noise0 = np.array([self._noise0[lvl]]).flatten()
         self._theta0 = list(self._theta0[lvl, :])
 
         self.X_norma = self.X_norma_all[lvl]
         self.y_norma = self.y_norma_all[lvl]
 
-        if self.options["eval_noise"]:
+        if self._eval_noise:
             if self.options["use_het_noise"]:
                 # hetGP works with unique design variables
                 (
@@ -84,7 +84,7 @@ class SMFK(MFK):
                 y_norma_unique = np.array(y_norma_unique).reshape(-1, 1)
 
                 # pointwise sensible estimates of the noise variances (see Ankenman et al., 2010)
-                self.optimal_noise = self.options["noise0"] * np.ones(self.nt_all[lvl])
+                self.optimal_noise = self._noise0 * np.ones(self.nt_all[lvl])
                 for i in range(self.nt_all[lvl]):
                     diff = self.y_norma[self.index_unique == i] - y_norma_unique[i]
                     if np.sum(diff**2) != 0.0:
@@ -96,7 +96,7 @@ class SMFK(MFK):
                 self.X_norma_all[lvl] = self.X_norma
                 self.y_norma_all[lvl] = self.y_norma
         else:
-            self.optimal_noise = self.options["noise0"] / self.y_std**2
+            self.optimal_noise = self._noise0 / self.y_std**2
             self.optimal_noise_all[lvl] = self.optimal_noise
 
         # Calculate matrix of distances D between samples
@@ -189,7 +189,7 @@ class SMFK(MFK):
                 self.optimal_theta[lvl],
             ) = self._optimize_hyperparam(D)
 
-            if self.options["eval_noise"] and not self.options["use_het_noise"]:
+            if self._eval_noise and not self.options["use_het_noise"]:
                 tmp_list = self.optimal_theta[lvl]
                 self.optimal_theta[lvl] = tmp_list[:-1]
                 self.optimal_noise = tmp_list[-1]

--- a/smt/applications/smfk.py
+++ b/smt/applications/smfk.py
@@ -60,7 +60,7 @@ class SMFK(MFK):
     def _new_train_iteration(self, lvl):
         # n_samples = self.nt_all
         self.options["noise0"] = np.array([self.options["noise0"][lvl]]).flatten()
-        self.options["theta0"] = self.options["theta0"][lvl, :]
+        self._theta0 = list(self._theta0[lvl, :])
 
         self.X_norma = self.X_norma_all[lvl]
         self.y_norma = self.y_norma_all[lvl]

--- a/smt/surrogate_models/kpls.py
+++ b/smt/surrogate_models/kpls.py
@@ -113,7 +113,7 @@ class KPLS(KrgBased):
             self.options["n_comp"] += 1
             press_m = press_m1
             press_m1 = 0
-            self.options["theta0"] = [0.1]
+            self._theta0 = [0.1]
             for fold in range(k_fold):
                 self.nt = len(X) - nbk
                 todel = np.arange(fold * nbk, (fold + 1) * nbk)
@@ -140,7 +140,7 @@ class KPLS(KrgBased):
         self.training_points[None][0][0] = X
         self.training_points[None][0][1] = y
         self.nt = len(X)
-        self.options["theta0"] = [0.1]
+        self._theta0 = [0.1]
 
     def _train(self):
         """

--- a/smt/surrogate_models/kpls.py
+++ b/smt/surrogate_models/kpls.py
@@ -90,7 +90,7 @@ class KPLS(KrgBased):
             self.options["corr"],
             self.options["n_comp"],
             self.coeff_pls,
-            power=self.options["pow_exp_power"],
+            power=self._pow_exp_power,
             theta=theta,
             return_derivative=return_derivative,
         )

--- a/smt/surrogate_models/kplsk.py
+++ b/smt/surrogate_models/kplsk.py
@@ -50,7 +50,7 @@ class KPLSK(KPLS):
                 self.options["corr"],
                 self.options["n_comp"],
                 self.coeff_pls,
-                power=self.options["pow_exp_power"],
+                power=self._pow_exp_power,
                 theta=theta,
                 return_derivative=return_derivative,
             )
@@ -60,7 +60,7 @@ class KPLSK(KPLS):
                 dx,
                 self.options["corr"],
                 self.nx,
-                power=self.options["pow_exp_power"],
+                power=self._pow_exp_power,
                 theta=theta,
                 return_derivative=return_derivative,
             )
@@ -81,7 +81,7 @@ class KPLSK(KPLS):
         _, _, best_theta = self._optimize_hyperparam(D)
 
         # Project PLS theta back to full Kriging space
-        if self.options["eval_noise"]:
+        if self._eval_noise:
             theta = best_theta[:-1]
         else:
             theta = best_theta
@@ -97,7 +97,7 @@ class KPLSK(KPLS):
             None,
             None,
         )
-        self.options["n_comp"] = int(self.n_param)
+        self._n_comp = int(self.n_param)
         self.best_iteration_fail = None
 
         # Second pass: optimize in full Kriging space (no multistart)
@@ -106,5 +106,5 @@ class KPLSK(KPLS):
         return self._optimize_hyperparam(
             D,
             use_multistart=False,
-            limit=10 * self.options["n_comp"],
+            limit=10 * self._n_comp,
         )

--- a/smt/surrogate_models/kplsk.py
+++ b/smt/surrogate_models/kplsk.py
@@ -87,9 +87,9 @@ class KPLSK(KPLS):
             theta = best_theta
 
         if self.options["corr"] == "squar_exp":
-            self.options["theta0"] = (theta * self.coeff_pls**2).sum(1)
+            self._theta0 = list((theta * self.coeff_pls**2).sum(1))
         else:
-            self.options["theta0"] = (theta * np.abs(self.coeff_pls)).sum(1)
+            self._theta0 = list((theta * np.abs(self.coeff_pls)).sum(1))
         self.n_param = compute_n_param(
             self.design_space,
             self.options["categorical_kernel"],

--- a/smt/surrogate_models/krg.py
+++ b/smt/surrogate_models/krg.py
@@ -35,7 +35,7 @@ class KRG(KrgBased):
             dx,
             self.options["corr"],
             self.nx,
-            self.options["pow_exp_power"],
+            self._pow_exp_power,
             theta=theta,
             return_derivative=return_derivative,
         )

--- a/smt/surrogate_models/krg_based/krg_based.py
+++ b/smt/surrogate_models/krg_based/krg_based.py
@@ -245,16 +245,17 @@ class KrgBased(SurrogateModel):
         if self.options["seed"]:
             self.random_state = np.random.default_rng(self.options["seed"])
 
-        # initialize default power values
+        # initialize default power values (working copy, don't mutate options)
+        self._pow_exp_power = self.options["pow_exp_power"]
         if self.options["corr"] == "squar_exp":
-            self.options["pow_exp_power"] = 2.0
+            self._pow_exp_power = 2.0
         elif self.options["corr"] in [
             "abs_exp",
             "squar_sin_exp",
             "matern32",
             "matern52",
         ] or isinstance(self.options["corr"], Kernel):
-            self.options["pow_exp_power"] = 1.0
+            self._pow_exp_power = 1.0
         # initialize kernel or link model with user defined kernel
         if isinstance(self.options["corr"], Kernel):
             if isinstance(self.options["corr"], Operator):
@@ -273,11 +274,9 @@ class KrgBased(SurrogateModel):
         else:
             raise ValueError("The correlation kernel has not been correctly defined.")
         # Check the pow_exp_power is >0 and <=2
-        assert (
-            self.options["pow_exp_power"] > 0 and self.options["pow_exp_power"] <= 2
-        ), (
+        assert self._pow_exp_power > 0 and self._pow_exp_power <= 2, (
             "The power value for exponential power function can only be >0 and <=2, but %s was given"
-            % self.options["pow_exp_power"]
+            % self._pow_exp_power
         )
 
     # --- Polymorphic hooks (override in subclasses instead of checking self.name) ---
@@ -331,7 +330,7 @@ class KrgBased(SurrogateModel):
         Default extracts noise from optimal_theta when eval_noise is enabled.
         Override in MGP (calls _specific_train) and SGP (extracts sigma2).
         """
-        if self.options["eval_noise"] and not self.options["use_het_noise"]:
+        if self._eval_noise and not self.options["use_het_noise"]:
             self.optimal_noise = self.optimal_theta[-1]
             self.optimal_theta = self.optimal_theta[:-1]
 
@@ -387,7 +386,7 @@ class KrgBased(SurrogateModel):
         -------
         HyperparamOptimizer
         """
-        hyper_opt = self.options["hyper_opt"]
+        hyper_opt = self._hyper_opt
         if isinstance(hyper_opt, HyperparamOptimizer):
             return hyper_opt
         if hyper_opt == "Cobyla":
@@ -576,8 +575,8 @@ class KrgBased(SurrogateModel):
             self.y_std,
         ) = standardization(X.copy(), y.copy())
 
-        if not self.options["eval_noise"]:
-            self.optimal_noise = np.array(self.options["noise0"])
+        if not self._eval_noise:
+            self.optimal_noise = np.array(self._noise0)
         elif self.options["use_het_noise"]:
             # hetGP works with unique design variables when noise variance are not given
             (
@@ -592,7 +591,7 @@ class KrgBased(SurrogateModel):
             for i in range(self.nt):
                 y_norma_unique.append(np.mean(self.y_norma[index_unique == i]))
             # pointwise sensible estimates of the noise variances (see Ankenman et al., 2010)
-            self.optimal_noise = self.options["noise0"] * np.ones(self.nt)
+            self.optimal_noise = self._noise0 * np.ones(self.nt)
             for i in range(self.nt):
                 diff = self.y_norma[index_unique == i] - y_norma_unique[i]
                 if np.sum(diff**2) != 0.0:
@@ -1079,7 +1078,7 @@ class KrgBased(SurrogateModel):
             r = self._matrix_data_corr(
                 corr=self.options["corr"],
                 design_space=self.design_space,
-                power=self.options["pow_exp_power"],
+                power=self._pow_exp_power,
                 theta=self.optimal_theta,
                 theta_bounds=self.options["theta_bounds"],
                 dx=dx,
@@ -1225,7 +1224,7 @@ class KrgBased(SurrogateModel):
             r = self._matrix_data_corr(
                 corr=self.options["corr"],
                 design_space=self.design_space,
-                power=self.options["pow_exp_power"],
+                power=self._pow_exp_power,
                 theta=self.optimal_theta,
                 theta_bounds=self.options["theta_bounds"],
                 dx=dx,
@@ -1253,7 +1252,7 @@ class KrgBased(SurrogateModel):
             np.dot(self.optimal_par["Ft"].T, rt)
             - self._regression_types[self.options["poly"]](X_cont).T,
         )
-        is_noisy = np.max(self.options["noise0"]) > 0.0 or self.options["eval_noise"]
+        is_noisy = np.max(self._noise0) > 0.0 or self._eval_noise
         if is_noisy and is_ri:
             A = self.optimal_par["sigma2_ri"]
         else:
@@ -1520,7 +1519,7 @@ class KrgBased(SurrogateModel):
         k, stop, best_optimal_rlf_value = 0, 1, -1e20
         while k < stop:
             # Use specified starting point as first guess
-            self.noise0 = np.array(self.options["noise0"])
+            self.noise0 = np.array(self._noise0)
             noise_bounds = self.options["noise_bounds"]
 
             # GP variance is optimized too when _optimize_sigma2 is True
@@ -1541,7 +1540,7 @@ class KrgBased(SurrogateModel):
                 theta0_rand = np.concatenate([theta0_rand, sigma2_0])
 
             if (
-                self.options["eval_noise"]
+                self._eval_noise
                 and not self.options["use_het_noise"]
                 and self.retry == MAX_RETRY
             ):
@@ -1696,6 +1695,14 @@ class KrgBased(SurrogateModel):
         This function checks some parameters of the model
         and amend theta0 if possible (see _amend_theta0_option).
         """
+        # Create working copies of mutable options to avoid mutating self.options
+        self._theta0 = list(self.options["theta0"])
+        self._eval_noise = getattr(
+            self, "_eval_noise_request", self.options["eval_noise"]
+        )
+        self._noise0 = list(self.options["noise0"])
+        self._hyper_opt = self.options["hyper_opt"]
+
         d = self.options["n_comp"] if "n_comp" in self.options else self.nx
 
         mat_dim = (
@@ -1762,28 +1769,28 @@ class KrgBased(SurrogateModel):
                         % (len(self._theta0), d)
                     )
         if (
-            self.options["eval_noise"] or np.max(self.options["noise0"]) > 1e-12
-        ) and self.options["hyper_opt"] == "TNC":
+            self._eval_noise or np.max(self._noise0) > 1e-12
+        ) and self._hyper_opt == "TNC":
             warnings.warn(
                 "TNC not available yet for noise handling. Switching to Cobyla"
             )
-            self.options["hyper_opt"] = "Cobyla"
+            self._hyper_opt = "Cobyla"
 
-        if self.options["use_het_noise"] and not self.options["eval_noise"]:
-            if len(self.options["noise0"]) != self.nt:
-                if len(self.options["noise0"]) == 1:
-                    self.options["noise0"] *= np.ones(self.nt)
+        if self.options["use_het_noise"] and not self._eval_noise:
+            if len(self._noise0) != self.nt:
+                if len(self._noise0) == 1:
+                    self._noise0 *= np.ones(self.nt)
                 else:
                     raise ValueError(
                         "for the heteroscedastic case, the length of noise0 (%s) \
                             should be equal to the number of observations (%s)."
-                        % (len(self.options["noise0"]), self.nt)
+                        % (len(self._noise0), self.nt)
                     )
         if not self.options["use_het_noise"]:
-            if len(self.options["noise0"]) != 1:
+            if len(self._noise0) != 1:
                 raise ValueError(
                     "for the homoscedastic noise case, the length of noise0 (%s) should be equal to one."
-                    % (len(self.options["noise0"]))
+                    % (len(self._noise0))
                 )
 
         if self.supports["training_derivatives"]:

--- a/smt/surrogate_models/krg_based/krg_based.py
+++ b/smt/surrogate_models/krg_based/krg_based.py
@@ -263,14 +263,13 @@ class KrgBased(SurrogateModel):
                 )
             else:
                 self.corr = self.options["corr"]
-            self.options["theta0"] = self.corr.theta
+            self._theta0 = self.corr.theta
         elif (
             type(self.options["corr"]) is str
             and self.options["corr"] in self._correlation_class
         ):
-            self.corr = self._correlation_class[self.options["corr"]](
-                self.options["theta0"]
-            )
+            self._theta0 = list(self.options["theta0"])
+            self.corr = self._correlation_class[self.options["corr"]](self._theta0)
         else:
             raise ValueError("The correlation kernel has not been correctly defined.")
         # Check the pow_exp_power is >0 and <=2
@@ -1465,7 +1464,7 @@ class KrgBased(SurrogateModel):
                 return hess
 
         if limit is None:
-            limit = max(12 * len(self.options["theta0"]), 50)
+            limit = max(12 * len(self._theta0), 50)
         _rhobeg = 0.5
 
         # Create optimizer strategy
@@ -1484,8 +1483,8 @@ class KrgBased(SurrogateModel):
         )
 
         bounds_hyp = []
-        self.theta0 = deepcopy(self.options["theta0"])
-        self.corr.theta = deepcopy(self.options["theta0"])
+        self.theta0 = deepcopy(self._theta0)
+        self.corr.theta = deepcopy(self._theta0)
         for i in range(len(self.theta0)):
             # In practice, in 1D and for X in [0,1], theta^{-2} in [1e-2,infty),
             # i.e. theta in (0,1e1], is a good choice to avoid overfitting.
@@ -1719,13 +1718,15 @@ class KrgBased(SurrogateModel):
                     self.is_continuous
                     or self.options["categorical_kernel"] == MixIntKernelType.GOWER
                 ):
-                    self.options["theta0"] *= np.ones(2 * self.n_param)
+                    self._theta0 = list(
+                        np.array(self._theta0) * np.ones(2 * self.n_param)
+                    )
                 else:
                     self.n_param += len([self.design_space.is_cat_mask])
-                    self.options["theta0"] *= np.ones(self.n_param)
+                    self._theta0 = list(np.array(self._theta0) * np.ones(self.n_param))
 
             else:
-                self.options["theta0"] *= np.ones(self.n_param)
+                self._theta0 = list(np.array(self._theta0) * np.ones(self.n_param))
         if (
             self.options["corr"] not in ["squar_exp", "abs_exp", "pow_exp"]
             and not (self.is_continuous)
@@ -1740,13 +1741,13 @@ class KrgBased(SurrogateModel):
                 "Categorical kernels should be matrix or exponential based."
             )
 
-        if len(self.options["theta0"]) != d and (
+        if len(self._theta0) != d and (
             self.options["categorical_kernel"]
             in [MixIntKernelType.GOWER, MixIntKernelType.COMPOUND_SYMMETRY]
             or self.is_continuous
         ):
-            if len(self.options["theta0"]) == 1:
-                self.options["theta0"] *= np.ones(d)
+            if len(self._theta0) == 1:
+                self._theta0 = list(np.array(self._theta0) * np.ones(d))
             else:
                 if self.options["corr"] in (
                     "pow_exp",
@@ -1758,7 +1759,7 @@ class KrgBased(SurrogateModel):
                 ):
                     raise ValueError(
                         "the length of theta0 (%s) should be equal to the number of dim (%s)."
-                        % (len(self.options["theta0"]), d)
+                        % (len(self._theta0), d)
                     )
         if (
             self.options["eval_noise"] or np.max(self.options["noise0"]) > 1e-12

--- a/smt/surrogate_models/krg_based/likelihood_eval.py
+++ b/smt/surrogate_models/krg_based/likelihood_eval.py
@@ -92,7 +92,7 @@ class LikelihoodEvaluator:
 
         # ---- nugget / noise ----
         nugget = m.options["nugget"]
-        if m.options["eval_noise"]:
+        if m._eval_noise:
             if m.options["is_ri"]:
                 nugget = 100.0 * np.finfo(np.double).eps
             else:
@@ -101,7 +101,7 @@ class LikelihoodEvaluator:
         tmp_var = theta
         if m.options["use_het_noise"]:
             noise = m.optimal_noise
-        if m.options["eval_noise"] and not m.options["use_het_noise"]:
+        if m._eval_noise and not m.options["use_het_noise"]:
             theta = tmp_var[0:-1]
             noise = tmp_var[-1]
 
@@ -114,7 +114,7 @@ class LikelihoodEvaluator:
                 r = m._matrix_data_corr(
                     corr=m.options["corr"],
                     design_space=m.design_space,
-                    power=m.options["pow_exp_power"],
+                    power=m._pow_exp_power,
                     theta=theta,
                     theta_bounds=m.options["theta_bounds"],
                     dx=dx,

--- a/smt/surrogate_models/krg_based/mixed_int_corr.py
+++ b/smt/surrogate_models/krg_based/mixed_int_corr.py
@@ -1002,7 +1002,7 @@ class MixedIntegerCorrelation:
                     "squar_exp",
                     model.options["n_comp"],
                     model.coeff_pls,
-                    power=model.options["pow_exp_power"],
+                    power=model._pow_exp_power,
                     theta=None,
                     return_derivative=False,
                 )

--- a/smt/surrogate_models/mgp.py
+++ b/smt/surrogate_models/mgp.py
@@ -541,6 +541,13 @@ class MGP(KrgBased):
         Overrides KrgBased implementation
         This function checks some parameters of the model.
         """
+        # Create working copies of mutable options to avoid mutating self.options
+        self._theta0 = list(self.options["theta0"])
+        self._eval_noise = getattr(
+            self, "_eval_noise_request", self.options["eval_noise"]
+        )
+        self._noise0 = list(self.options["noise0"])
+        self._hyper_opt = self.options["hyper_opt"]
 
         d = self.options["n_comp"] * self.nx
 

--- a/smt/surrogate_models/mgp.py
+++ b/smt/surrogate_models/mgp.py
@@ -549,11 +549,11 @@ class MGP(KrgBased):
         if self.options["hyper_opt"] != "TNC":
             raise ValueError("MGP must be used with TNC hyperparameters optimizer")
 
-        if len(self.options["theta0"]) != d:
-            if len(self.options["theta0"]) == 1:
-                self.options["theta0"] *= np.ones(d)
+        if len(self._theta0) != d:
+            if len(self._theta0) == 1:
+                self._theta0 = list(np.array(self._theta0) * np.ones(d))
             else:
                 raise ValueError(
                     "the number of dim %s should be equal to the length of theta0 %s."
-                    % (d, len(self.options["theta0"]))
+                    % (d, len(self._theta0))
                 )

--- a/smt/surrogate_models/sgp.py
+++ b/smt/surrogate_models/sgp.py
@@ -121,7 +121,7 @@ class SGP(KRG):
     def _post_optim_hook(self):
         """SGP extracts sigma2 (and optionally noise) from optimal_theta."""
         if not self.options["use_het_noise"]:
-            if self.options["eval_noise"]:
+            if self._eval_noise:
                 self.optimal_noise = self.optimal_theta[-1]
                 self.optimal_sigma2 = self.optimal_theta[-2]
                 self.optimal_theta = self.optimal_theta[:-2]
@@ -217,13 +217,13 @@ class SGP(KRG):
         Y = self.training_points[None][0][1]
         Z = self.Z
 
-        if self.options["eval_noise"]:
+        if self._eval_noise:
             sigma2 = theta[-2]
             noise = theta[-1]
             theta = theta[0:-2]
         else:
             sigma2 = theta[-1]
-            noise = self.options["noise0"]
+            noise = self._noise0
             theta = theta[0:-1]
 
         nugget = self.options["nugget"]

--- a/smt/surrogate_models/tests/test_krg_based.py
+++ b/smt/surrogate_models/tests/test_krg_based.py
@@ -25,13 +25,17 @@ class TestKrgBased(unittest.TestCase):
         krg = KrgBased()
         krg.set_training_values(np.array([[1, 2, 3]]), np.array([[1]]))
         krg._check_param()
-        self.assertTrue(np.array_equal(krg.options["theta0"], [1e-2, 1e-2, 1e-2]))
+        self.assertTrue(np.array_equal(krg._theta0, [1e-2, 1e-2, 1e-2]))
+        # options["theta0"] should NOT be mutated
+        self.assertTrue(np.array_equal(krg.options["theta0"], [1e-2]))
 
     def test_theta0_one_dim_init(self):
         krg = KrgBased(theta0=[2e-2])
         krg.set_training_values(np.array([[1, 2, 3]]), np.array([[1]]))
         krg._check_param()
-        self.assertTrue(np.array_equal(krg.options["theta0"], [2e-2, 2e-2, 2e-2]))
+        self.assertTrue(np.array_equal(krg._theta0, [2e-2, 2e-2, 2e-2]))
+        # options["theta0"] should NOT be mutated
+        self.assertTrue(np.array_equal(krg.options["theta0"], [2e-2]))
 
     def test_theta0_erroneous_init(self):
         krg = KrgBased(theta0=[2e-2, 1e-2])


### PR DESCRIPTION
This PR refactors several surrogate model classes in the `smt/applications` directory to consistently use internal attributes (prefixed with `_`) for mutable hyperparameters and options, rather than accessing or modifying the `options` dictionary directly. This change improves code safety by preventing unintended side effects from mutating shared configuration objects, and makes the codebase more maintainable and robust. The changes affect handling of parameters such as `theta0`, `noise0`, `eval_noise`, and `pow_exp_power` across multiple classes.

**Refactoring of internal hyperparameter management:**

* Replaced all direct accesses and mutations of `self.options["theta0"]`, `self.options["noise0"]`, `self.options["eval_noise"]`, and `self.options["pow_exp_power"]` with corresponding internal attributes (e.g., `self._theta0`, `self._noise0`, `self._eval_noise`, `self._pow_exp_power`) in `mfk.py`, `mfck.py`, `mfkpls.py`, `mfkplsk.py`, `smfk.py`, and `cckrg.py`. This includes copying or deep-copying mutable objects to avoid side effects. [[1]](diffhunk://#diff-feb315597c4d8e5c0da97342466691521644b5413b5d0515b3569bb0d2be3ea7R1021-R1029) [[2]](diffhunk://#diff-dde18eed106be94890c1095af300b4680faa99ede1ae014400338da21264c9ceL117-R117) [[3]](diffhunk://#diff-7cc0ccff7918fadafc536bdd86c6e0b9f9ef36235141d72cca73f503287f6554L66-R66) [[4]](diffhunk://#diff-dde373978e6bc12e1d90b302a237f3da5d955883fd2d53b3b9c644f64f65f90fR14) [[5]](diffhunk://#diff-9434b627c20bc24608b36b8898195ed7ed9dedbc020944c78c24669c803c15b9L62-R68) [[6]](diffhunk://#diff-7fb5ff54ea6b190f35d039a7b47f8283791617dee9ba806199ffbd867f306d0cL166-R166)

**Consistent parameter initialization and shape validation:**

* Updated parameter shape checks and initializations in `_check_param` methods to use the new internal attributes, ensuring proper handling of array shapes and sizes for multi-fidelity and multi-level models.

**Noise and theta handling in training routines:**

* All training routines (`_new_train`, `_new_train_iteration`, `train`) now use internal attributes for noise and theta parameters, including correct handling of array copying, reshaping, and broadcasting across fidelity levels. [[1]](diffhunk://#diff-feb315597c4d8e5c0da97342466691521644b5413b5d0515b3569bb0d2be3ea7L287-R293) [[2]](diffhunk://#diff-dde18eed106be94890c1095af300b4680faa99ede1ae014400338da21264c9ceL141-R141) [[3]](diffhunk://#diff-9434b627c20bc24608b36b8898195ed7ed9dedbc020944c78c24669c803c15b9L62-R68) [[4]](diffhunk://#diff-7fb5ff54ea6b190f35d039a7b47f8283791617dee9ba806199ffbd867f306d0cL191-R191)

**Componentwise distance calculations:**

* Updated all calls to `componentwise_distance` to use the internal attribute `self._pow_exp_power` instead of reading from `self.options`, ensuring that the correct (possibly mutated) value is always used. [[1]](diffhunk://#diff-feb315597c4d8e5c0da97342466691521644b5413b5d0515b3569bb0d2be3ea7L527-R533) [[2]](diffhunk://#diff-7cc0ccff7918fadafc536bdd86c6e0b9f9ef36235141d72cca73f503287f6554L66-R66) [[3]](diffhunk://#diff-dde373978e6bc12e1d90b302a237f3da5d955883fd2d53b3b9c644f64f65f90fL53-R54)

**PLS and Kriging-specific changes:**

* In `mfkplsk.py`, replaced use of `self.options["n_comp"]` and related parameters with internal attributes (e.g., `self._n_comp`) to ensure correct tracking and usage of the number of components throughout the optimization process. [[1]](diffhunk://#diff-dde373978e6bc12e1d90b302a237f3da5d955883fd2d53b3b9c644f64f65f90fL72-R89) [[2]](diffhunk://#diff-dde373978e6bc12e1d90b302a237f3da5d955883fd2d53b3b9c644f64f65f90fL97-R98) [[3]](diffhunk://#diff-dde373978e6bc12e1d90b302a237f3da5d955883fd2d53b3b9c644f64f65f90fL106-R113)