### PR TITLE
Fix kriging-based surrogates training with custom kernel

### DIFF
--- a/smt/kernels/kernels.py
+++ b/smt/kernels/kernels.py
@@ -7,6 +7,14 @@ class Kernel(metaclass=ABCMeta):
     def __init__(self, theta):
         self.theta = np.atleast_1d(theta)
 
+    @property
+    def theta(self):
+        return self._theta
+
+    @theta.setter
+    def theta(self, theta):
+        self._theta = np.atleast_1d(theta)
+
     def __add__(self, k):
         if not isinstance(k, Kernel):
             return Sum(self, Constant(k))
@@ -560,7 +568,8 @@ class Operator(Kernel):
 
     @theta.setter
     def theta(self, theta):
-        n = self.corr1.theta.shape[0]
+        theta = np.atleast_1d(theta)
+        n = np.atleast_1d(self.corr1.theta).shape[0]
         self.corr1.theta = theta[:n]
         self.corr2.theta = theta[n:]
 

--- a/smt/surrogate_models/krg_based/krg_based.py
+++ b/smt/surrogate_models/krg_based/krg_based.py
@@ -1715,7 +1715,10 @@ class KrgBased(SurrogateModel):
         and amend theta0 if possible (see _amend_theta0_option).
         """
         # Create working copies of mutable options to avoid mutating self.options
-        self._theta0 = list(self.options["theta0"])
+        if isinstance(self.options["corr"], Kernel):
+            self._theta0 = list(np.atleast_1d(self.corr.theta))
+        else:
+            self._theta0 = list(self.options["theta0"])
         self._eval_noise = getattr(
             self, "_eval_noise_request", self.options["eval_noise"]
         )
@@ -1763,9 +1766,13 @@ class KrgBased(SurrogateModel):
                 "Categorical kernels should be matrix or exponential based."
             )
 
-        if len(self._theta0) != d and (
-            self.options["categorical_kernel"].is_scalar_encoding()
-            or self.is_continuous
+        if (
+            not isinstance(self.options["corr"], Kernel)
+            and len(self._theta0) != d
+            and (
+                self.options["categorical_kernel"].is_scalar_encoding()
+                or self.is_continuous
+            )
         ):
             if len(self._theta0) == 1:
                 self._theta0 = list(np.array(self._theta0) * np.ones(d))

--- a/smt/surrogate_models/tests/test_krg_training.py
+++ b/smt/surrogate_models/tests/test_krg_training.py
@@ -14,6 +14,7 @@ import numpy as np
 
 from smt.kernels import (
     ActExp,
+    Kernel,
     Matern32,
     Matern52,
     PowExp,
@@ -100,6 +101,38 @@ class Test(SMTestCase):
         sm.set_training_values(xt, yt)
         sm.train()
         self.assert_error(np.array(sm.optimal_theta), np.array([1.6]), 1e-1, 1e-1)
+
+    def test_custom_composed_kernel_training(self):
+        class RatQuad(Kernel):
+            def __call__(self, d, grad_ind=None, hess_ind=None, derivative_params=None):
+                n_theta = self.theta.shape[0]
+                theta_1 = self.theta[: n_theta // 2]
+                theta_2 = self.theta[n_theta // 2 :]
+                return (1.0 + d**2 / (2.0 * theta_1 * theta_2)) ** (-theta_1)
+
+        xt = np.linspace(0.0, 1.0, 8).reshape(-1, 1)
+        yt = np.sin(2.0 * np.pi * xt)
+        kernel = (
+            Matern32([0.01])
+            + SquarSinExp([0.01, 0.01]) * PowExp([0.01])
+            + RatQuad([0.01, 0.01])
+        )
+
+        sm = KRG(
+            corr=kernel,
+            hyper_opt="Cobyla",
+            n_start=5,
+            poly="linear",
+            print_global=False,
+        )
+
+        sm.set_training_values(xt, yt)
+        sm.train()
+
+        self.assertEqual(len(sm.optimal_theta), 6)
+        self.assertEqual(sm.corr.theta.shape[0], 6)
+        y_pred = sm.predict_values(np.array([[0.1], [0.5], [0.9]]))
+        self.assertEqual(y_pred.shape, (3, 1))
 
     def test_corr_derivatives(self):
         for ind, corr in enumerate(self.corr_def):  # For every kernel


### PR DESCRIPTION
Notebooks on kernels were failing following changes made in PR #794 (ie smt 2.13) which removes `self.options["theta0"]` mutability.
This PR fixes theta/theta0 initialization when a custom kernel is used. 