### PR TITLE
Use pydoe instead of archived pyDOE3

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ To cite SMT legacy: M. A. Bouhlel and J. T. Hwang and N. Bartoli and R. Lafage a
 
 # Required packages
 
-SMT depends on the following modules: numpy, scipy, scikit-learn, pyDOE3 and Cython.
+SMT depends on the following modules: numpy, scipy, scikit-learn, pydoe and Cython.
 
 # Installation
 

--- a/doc/_src_docs/sampling_methods/lhs.rst
+++ b/doc/_src_docs/sampling_methods/lhs.rst
@@ -4,7 +4,7 @@ Latin Hypercube sampling
 The LHS design is a statistical method for generating a quasi-random sampling distribution. It is among the most popular sampling techniques in computer experiments thanks to its simplicity and projection properties with high-dimensional problems. LHS is built as follows: we cut each dimension space, which represents a variable, into n
 sections where n is the number of sampling points, and we put only one point in each section.
 
-The LHS method uses the pyDOE package (Design of Experiments for Python) [1]_. Five criteria for the construction of LHS are implemented in SMT:
+The LHS method uses the pydoe package (Design of Experiments for Python) [1]_. Five criteria for the construction of LHS are implemented in SMT:
 
 - Center the points within the sampling intervals.
 - Maximize the minimum distance between points and place the point in a randomized location within its interval.
@@ -12,9 +12,9 @@ The LHS method uses the pyDOE package (Design of Experiments for Python) [1]_. F
 - Minimize the maximum correlation coefficient.
 - Optimize the design using the Enhanced Stochastic Evolutionary algorithm (ESE).
 
-The four first criteria are the same than in pyDOE (for more details, see [1]_). The last criterion, ESE, is implemented by the authors of SMT (more details about such method could be found in [2]_).
+The four first criteria are the same than in pydoe (for more details, see [1]_). The last criterion, ESE, is implemented by the authors of SMT (more details about such method could be found in [2]_).
 
-.. [1] https://pydoe3.readthedocs.io/en/stable
+.. [1] https://pydoe.github.io/pydoe/
 
 .. [2] Jin, R. and Chen, W. and Sudjianto, A. (2005), "An efficient algorithm for constructing optimal design of computer experiments." Journal of Statistical Planning and Inference, 134:268-287.
 

--- a/doc/_src_docs/sampling_methods/lhs.rstx
+++ b/doc/_src_docs/sampling_methods/lhs.rstx
@@ -4,7 +4,7 @@ Latin Hypercube sampling
 The LHS design is a statistical method for generating a quasi-random sampling distribution. It is among the most popular sampling techniques in computer experiments thanks to its simplicity and projection properties with high-dimensional problems. LHS is built as follows: we cut each dimension space, which represents a variable, into n
 sections where n is the number of sampling points, and we put only one point in each section.
 
-The LHS method uses the pyDOE package (Design of Experiments for Python) [1]_. Five criteria for the construction of LHS are implemented in SMT:
+The LHS method uses the pydoe package (Design of Experiments for Python) [1]_. Five criteria for the construction of LHS are implemented in SMT:
 
 - Center the points within the sampling intervals.
 - Maximize the minimum distance between points and place the point in a randomized location within its interval.
@@ -12,9 +12,9 @@ The LHS method uses the pyDOE package (Design of Experiments for Python) [1]_. F
 - Minimize the maximum correlation coefficient.
 - Optimize the design using the Enhanced Stochastic Evolutionary algorithm (ESE).
 
-The four first criteria are the same than in pyDOE (for more details, see [1]_). The last criterion, ESE, is implemented by the authors of SMT (more details about such method could be found in [2]_).
+The four first criteria are the same than in pydoe (for more details, see [1]_). The last criterion, ESE, is implemented by the authors of SMT (more details about such method could be found in [2]_).
 
-.. [1] https://pydoe3.readthedocs.io/en/stable
+.. [1] https://pydoe.github.io/pydoe/
 
 .. [2] Jin, R. and Chen, W. and Sudjianto, A. (2005), "An efficient algorithm for constructing optimal design of computer experiments." Journal of Statistical Planning and Inference, 134:268-287.
 

--- a/doc/_src_docs/sampling_methods/pydoe.rst
+++ b/doc/_src_docs/sampling_methods/pydoe.rst
@@ -1,12 +1,12 @@
-pyDOE sampling methods
+pydoe sampling methods
 ======================
 
-pyDOE is a package for design of experiments [1]_ (LHS implementation in SMT is based on pyDOE LHS). 
+pydoe is a package for design of experiments [1]_ (LHS implementation in SMT is based on pydoe LHS). 
 
-Main DOE functions provided by pyDOE are made available through an adapter base 
+Main DOE functions provided by pydoe are made available through an adapter base 
 class `PyDoeSamplingMethod` which makes them compliant with the `SamplingMethod` base class interface.
 
-While historically the sampling method interface of SMT requires to specify a number of points, pyDOE design
+While historically the sampling method interface of SMT requires to specify a number of points, pydoe design
 methods output a number of points which is only determined by the dimension of x and other method-specific options.
 
 The following designs are exposed:
@@ -16,13 +16,13 @@ The following designs are exposed:
 * Factorial design
 * Generalized Subset Design
 
-See pyDOE3 documentation [2]_
+See pydoe documentation [2]_
 
 References
 
-.. [1] https://github.com/relf/pyDOE3 
+.. [1] https://github.com/pydoe/pydoe 
 
-.. [2] https://pydoe3.readthedocs.io/en/stable 
+.. [2] https://pydoe.github.io/pydoe/ 
 
 
 Box Behnken sampling

--- a/doc/_src_docs/sampling_methods/pydoe.rstx
+++ b/doc/_src_docs/sampling_methods/pydoe.rstx
@@ -1,12 +1,12 @@
-pyDOE sampling methods
+pydoe sampling methods
 ======================
 
-pyDOE is a package for design of experiments [1]_ (LHS implementation in SMT is based on pyDOE LHS). 
+pydoe is a package for design of experiments [1]_ (LHS implementation in SMT is based on pydoe LHS). 
 
-Main DOE functions provided by pyDOE are made available through an adapter base 
+Main DOE functions provided by pydoe are made available through an adapter base 
 class `PyDoeSamplingMethod` which makes them compliant with the `SamplingMethod` base class interface.
 
-While historically the sampling method interface of SMT requires to specify a number of points, pyDOE design
+While historically the sampling method interface of SMT requires to specify a number of points, pydoe design
 methods output a number of points which is only determined by the dimension of x and other method-specific options.
 
 The following designs are exposed:
@@ -16,13 +16,13 @@ The following designs are exposed:
 * Factorial design
 * Generalized Subset Design
 
-See pyDOE3 documentation [2]_
+See pydoe documentation [2]_
 
 References
 
-.. [1] https://github.com/relf/pyDOE3 
+.. [1] https://github.com/pydoe/pydoe 
 
-.. [2] https://pydoe3.readthedocs.io/en/stable 
+.. [2] https://pydoe.github.io/pydoe/ 
 
 
 Box Behnken sampling

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -3,7 +3,7 @@ packaging
 numpy
 scipy
 scikit-learn
-pyDOE3 >= 1.5.0
+pydoe >= 1.0.0, <2.0
 numpydoc
 matplotlib
 jenn >= 2.0.0, <3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 dependencies = [
     "packaging",
     "scikit-learn",
-    "pyDOE3>=1.5.0",
+    "pydoe>=1.0.0,<2.0",
     "scipy",
     "jenn>=2.0.0,<3.0",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ packaging
 numpy
 scipy
 scikit-learn
-pyDOE3 >= 1.5.0
+pydoe >= 1.0.0, <2.0
 numba           # JIT compiler
 matplotlib      # used in examples and tests
 pytest          # tests runner

--- a/smt/sampling_methods/lhs.py
+++ b/smt/sampling_methods/lhs.py
@@ -3,11 +3,11 @@ Author: Dr. John T. Hwang <hwangjt@umich.edu>
 
 This package is distributed under New BSD license.
 
-LHS sampling; uses the pyDOE3 package.
+LHS sampling; uses the pydoe package.
 """
 
 import numpy as np
-from pyDOE3 import lhs
+from pydoe import lhs
 from scipy.spatial.distance import cdist, pdist
 
 from smt.sampling_methods.sampling_method import ScaledSamplingMethod

--- a/smt/sampling_methods/pydoe.py
+++ b/smt/sampling_methods/pydoe.py
@@ -3,19 +3,19 @@ Author: Antoine Averland <antoine.averland@onera.fr> and Rémi Lafage <remi.lafa
 
 This package is distributed under New BSD license.
 
-pyDOE3 sampling methods
+pydoe sampling methods
 """
 
 import numpy as np
-from pyDOE3 import doe_box_behnken, doe_factorial, doe_gsd, doe_plackett_burman
+from pydoe import bbdesign, fullfact, gsd, pbdesign
 
 from smt.sampling_methods.sampling_method import SamplingMethod
 
 
 class PyDoeSamplingMethod(SamplingMethod):
     """
-    Base class adapting pyDOE3 designs to SMT SamplingMethod interface
-    See https://pydoe3.readthedocs.io/
+    Base class adapting pydoe designs to SMT SamplingMethod interface
+    See https://pydoe.github.io/pydoe/
     """
 
     def __init__(self, **kwargs):
@@ -25,14 +25,14 @@ class PyDoeSamplingMethod(SamplingMethod):
 
     def _compute(self, nt: int = None):
         """
-        Use pydoe3 design to produce [nsamples, nx] matrix
-        where nsamples depends on the pyDOE3 method and nx is the dimension of x.
-        Warning: In pyDOE3 design setting user requested number of points nt is not used
+        Use pydoe design to produce [nsamples, nx] matrix
+        where nsamples depends on the pydoe method and nx is the dimension of x.
+        Warning: In pydoe design setting user requested number of points nt is not used
         """
         xlimits = self.options["xlimits"]
         levels = self.levels
 
-        # Retrieve indices from pyDOE3 design
+        # Retrieve indices from pydoe design
         doe = np.array(self._compute_doe(), dtype=int)
 
         # Compute scaled values for each x components
@@ -66,7 +66,7 @@ class PyDoeSamplingMethod(SamplingMethod):
 
 
 class BoxBehnken(PyDoeSamplingMethod):
-    """See https://pydoe3.readthedocs.io/en/latest/rsm.html#box-behnken"""
+    """See https://pydoe.github.io/pydoe/rsm.html#box-behnken"""
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -76,11 +76,11 @@ class BoxBehnken(PyDoeSamplingMethod):
 
     def _compute_doe(self):
         # Increment Box Behnken levels to get indices [0, 1, 2]
-        return doe_box_behnken.bbdesign(self.nx) + 1
+        return bbdesign(self.nx) + 1
 
 
 class Gsd(PyDoeSamplingMethod):
-    """See https://pydoe3.readthedocs.io/en/latest/rsm.html#gsd"""
+    """See https://pydoe.github.io/pydoe/rsm.html#gsd"""
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -105,11 +105,11 @@ class Gsd(PyDoeSamplingMethod):
         levels = self.options["levels"]
         reduction = self.options["reduction"]
 
-        return doe_gsd.gsd(levels, reduction)
+        return gsd(levels, reduction)
 
 
 class Factorial(PyDoeSamplingMethod):
-    """See https://pydoe3.readthedocs.io/en/latest/factorial.html#general-full-factorial"""
+    """See https://pydoe.github.io/pydoe/factorial.html#general-full-factorial"""
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -125,11 +125,11 @@ class Factorial(PyDoeSamplingMethod):
 
     def _compute_doe(self):
         levels = self.options["levels"]
-        return doe_factorial.fullfact(levels)
+        return fullfact(levels)
 
 
 class PlackettBurman(PyDoeSamplingMethod):
-    """See https://pydoe3.readthedocs.io/en/latest/factorial.html#plackett-burman"""
+    """See https://pydoe.github.io/pydoe/factorial.html#plackett-burman"""
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -138,7 +138,7 @@ class PlackettBurman(PyDoeSamplingMethod):
         self.levels = [2] * self.nx
 
     def _compute_doe(self):
-        doe = doe_plackett_burman.pbdesign(self.nx)
+        doe = pbdesign(self.nx)
         # Change -1 level to get indices [0, 1]
         doe[doe < 0] = 0
 

--- a/smt/sampling_methods/tests/test_pydoe.py
+++ b/smt/sampling_methods/tests/test_pydoe.py
@@ -5,7 +5,7 @@ import numpy as np
 from smt.sampling_methods import pydoe
 
 
-class TestPyDOE3(unittest.TestCase):
+class TestPyDOE(unittest.TestCase):
     def test_bbdesign(self):
         xlimits = np.array([[2.0, 5], [-5, 1], [0, 3]])
         sampling = pydoe.BoxBehnken(xlimits=xlimits)

--- a/smt/surrogate_models/krg_based/distances.py
+++ b/smt/surrogate_models/krg_based/distances.py
@@ -37,7 +37,7 @@ njit_use
 import os
 
 import numpy as np
-from pyDOE3 import bbdesign
+from pydoe import bbdesign
 from sklearn.cross_decomposition import PLSRegression as pls
 from sklearn.metrics.pairwise import check_pairwise_arrays
 

--- a/tutorial/SMT_Tutorial.ipynb
+++ b/tutorial/SMT_Tutorial.ipynb
@@ -3801,9 +3801,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "myenvSMT",
+   "display_name": "base",
    "language": "python",
-   "name": "myenvsmt"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -3815,7 +3815,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.13"
+   "version": "3.12.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
`pyDOE3` is no longer actively maintained.

The project originated as a continuation of `pyDOE`, but active development has since returned to the main [pydoe ](https://github.com/pydoe/pydoe) package. 