### PR TITLE
Add the possibility to give an array-like input for n_comp option in KPLS

### DIFF
--- a/doc/_src_docs/surrogate_models/gpr/kpls.rst
+++ b/doc/_src_docs/surrogate_models/gpr/kpls.rst
@@ -83,7 +83,7 @@ Usage
    Training
      
      Training ...
-     Training - done. Time (sec):  0.0683827
+     Training - done. Time (sec):  0.0968523
   ___________________________________________________________________________
      
    Evaluation
@@ -91,9 +91,9 @@ Usage
         # eval points. : 100
      
      Predicting ...
-     Predicting - done. Time (sec):  0.0000000
+     Predicting - done. Time (sec):  0.0002611
      
-     Prediction time/pt. (sec) :  0.0000000
+     Prediction time/pt. (sec) :  0.0000026
      
   ___________________________________________________________________________
      
@@ -102,9 +102,9 @@ Usage
         # eval points. : 5
      
      Predicting ...
-     Predicting - done. Time (sec):  0.0000000
+     Predicting - done. Time (sec):  0.0003815
      
-     Prediction time/pt. (sec) :  0.0000000
+     Prediction time/pt. (sec) :  0.0000763
      
   
 .. figure:: kpls_Test_test_kpls.png
@@ -126,14 +126,17 @@ Usage with an automatic number of components
   ndim = 10
   prob = TensorProduct(ndim=ndim, func="exp")
   
-  sm = KPLS(eval_n_comp=True)
+  sm = KPLS(
+      eval_n_comp=True,
+      eval_n_comp_strategy="wold",
+  )
   samp = LHS(xlimits=prob.xlimits, seed=42)
   xt = samp(50)
   yt = prob(xt)
   sm.set_training_values(xt, yt)
   sm.train()
   
-  ## The model automatically choose a dimension of 3
+  ## The model automatically choose a dimension of 5
   ncomp = sm.options["n_comp"]
   print("\n The model automatically choose " + str(ncomp) + " components.")
   
@@ -165,7 +168,7 @@ Usage with an automatic number of components
    Training
      
      Training ...
-     Training - done. Time (sec): 25.7292035
+     Training - done. Time (sec): 87.2217591
   
    The model automatically choose 5 components.
   ___________________________________________________________________________
@@ -175,12 +178,90 @@ Usage with an automatic number of components
         # eval points. : 1
      
      Predicting ...
-     Predicting - done. Time (sec):  0.0000000
+     Predicting - done. Time (sec):  0.0002754
      
-     Prediction time/pt. (sec) :  0.0000000
+     Prediction time/pt. (sec) :  0.0002754
      
-  [[2.73415806]]
-  [[40.38142763]]
+  [[2.73415724]]
+  [[40.38142747]]
+  
+
+Usage with a range of number of components
+--------------------------------------------
+
+.. code-block:: python
+
+  import numpy as np
+  
+  from smt.problems import TensorProduct
+  from smt.sampling_methods import LHS
+  from smt.surrogate_models import KPLS
+  
+  # The problem is the exponential problem with dimension 10
+  ndim = 10
+  prob = TensorProduct(ndim=ndim, func="exp")
+  
+  n_comp_range = [2, 6]  # We explore the range [1, 5] n_dim and we chose the best
+  
+  sm = KPLS(
+      eval_n_comp=True,
+      eval_n_comp_strategy="exhaustive",
+      range_n_comp_exhaustive=n_comp_range,
+  )
+  samp = LHS(xlimits=prob.xlimits, seed=42)
+  xt = samp(50)
+  yt = prob(xt)
+  sm.set_training_values(xt, yt)
+  sm.train()
+  
+  ## The model automatically choose a dimension of 5
+  ncomp = sm.options["n_comp"]
+  print("\n The model automatically choose " + str(ncomp) + " components.")
+  
+  ## You can predict a 10-dimension point from the 3-dimensional model
+  print(
+      sm.predict_values(
+          np.array([[-0.9, -0.7, -0.5, -0.3, -0.1, 0.1, 0.3, 0.5, 0.7, 0.9]])
+      )
+  )
+  print(
+      sm.predict_variances(
+          np.array([[-0.9, -0.7, -0.5, -0.3, -0.1, 0.1, 0.3, 0.5, 0.7, 0.9]])
+      )
+  )
+  
+::
+
+  ___________________________________________________________________________
+     
+                                     KPLS
+  ___________________________________________________________________________
+     
+   Problem size
+     
+        # training points.        : 50
+     
+  ___________________________________________________________________________
+     
+   Training
+     
+     Training ...
+     Training - done. Time (sec): 59.3835318
+  
+   The model automatically choose 5 components.
+  ___________________________________________________________________________
+     
+   Evaluation
+     
+        # eval points. : 1
+     
+     Predicting ...
+     Predicting - done. Time (sec):  0.0003910
+     
+     Prediction time/pt. (sec) :  0.0003910
+     
+  [[2.73416137]]
+  [[40.38140393]]
   
 
 Options
@@ -320,17 +401,27 @@ Options
      -  1
      -  None
      -  ['int']
-     -  Number of principal components
+     -  Number of principal components. Only used when eval_n_comp=False. Ignored when eval_n_comp=True (the optimal value is estimated instead).
   *  -  eval_n_comp
      -  False
      -  [True, False]
      -  ['bool']
-     -  n_comp evaluation flag
+     -  If True, the optimal number of components is estimated automatically using the strategy defined by eval_n_comp_strategy. If False, the value of n_comp is used directly.
   *  -  eval_comp_treshold
      -  1.0
      -  None
      -  ['float']
-     -  n_comp evaluation treshold for Wold's R criterion
+     -  Threshold for Wold's R criterion (used when eval_n_comp_strategy='wold').
+  *  -  eval_n_comp_strategy
+     -  wold
+     -  ['wold', 'exhaustive']
+     -  ['str']
+     -  Strategy used to estimate the optimal number of components when eval_n_comp=True. 'wold': increments n_comp until the cross-validation error stops decreasing (early stopping via Wold's R criterion). 'exhaustive': evaluates all values in range_n_comp_exhaustive and picks the global minimum.
+  *  -  range_n_comp_exhaustive
+     -  None
+     -  None
+     -  ['list', 'tuple', 'ndarray', 'NoneType']
+     -  Search range [n_min, n_max] (inclusive) for the exhaustive strategy. Only used when eval_n_comp=True and eval_n_comp_strategy='exhaustive'. If None, defaults to [1, max(1, n_features // 10)].
   *  -  cat_kernel_comps
      -  None
      -  None

--- a/doc/_src_docs/surrogate_models/gpr/kpls.rstx
+++ b/doc/_src_docs/surrogate_models/gpr/kpls.rstx
@@ -31,6 +31,11 @@ Usage with an automatic number of components
 
 .. embed-test-print :: smt.surrogate_models.tests.test_surrogate_model_examples , Test , test_kpls_auto
 
+Usage with a range of number of components
+--------------------------------------------
+
+.. embed-test-print :: smt.surrogate_models.tests.test_surrogate_model_examples , Test , test_kpls_range
+
 Options
 -------
 

--- a/smt/surrogate_models/kpls.py
+++ b/smt/surrogate_models/kpls.py
@@ -21,7 +21,6 @@ class KPLS(KrgBased):
     def _initialize(self):
         super(KPLS, self)._initialize()
         declare = self.options.declare
-
         declare(
             "n_comp",
             1,
@@ -165,11 +164,11 @@ class KPLS(KrgBased):
 
         Parameters
         ----------
-        X : ndarray, shape (original_nt, n_features) — full training inputs, never mutated
-        y : ndarray, shape (original_nt, n_outputs)  — full training outputs, never mutated
-        n_comp : int — number of PLS components to use
-        k_fold : int — number of folds
-        original_nt : int — size of the full dataset; used to compute fold width
+        X : ndarray, shape (original_nt, n_features), full training inputs, never mutated
+        y : ndarray, shape (original_nt, n_outputs), full training outputs, never mutated
+        n_comp : int, number of PLS components to use
+        k_fold : int, number of folds
+        original_nt : int, size of the full dataset; used to compute fold width
                       and the PRESS normalisation factor. Passed explicitly so
                       this method does not depend on self.nt, which may have
                       been overwritten by a previous fold.
@@ -255,6 +254,8 @@ class KPLS(KrgBased):
                 if error < best_error:
                     best_error = error
                     best_comp = n_comp
+        else:
+            raise ValueError("Strategy '" + strategy + "' not implemented.")
 
         # Restore training data and state
         self.training_points[None][0][0] = X

--- a/smt/surrogate_models/kpls.py
+++ b/smt/surrogate_models/kpls.py
@@ -160,6 +160,11 @@ class KPLS(KrgBased):
         nbk = int(self.nt / k_fold)
         press_m = []
         n_comp_min, n_comp_max = map(int, self.options["n_comp"])  # We want int only
+        if n_comp_min >= n_comp_max:
+            raise ValueError(
+                "n_comp must be an integer or an array-like of length 2 "
+                "[min_n_comp, max_n_comp], with min_n_comp < max_n_comp"
+            )
         n_comp_values = list(range(n_comp_min, n_comp_max + 1))
         for n_comp in n_comp_values:
             self.options["n_comp"] = n_comp

--- a/smt/surrogate_models/kpls.py
+++ b/smt/surrogate_models/kpls.py
@@ -21,7 +21,12 @@ class KPLS(KrgBased):
     def _initialize(self):
         super(KPLS, self)._initialize()
         declare = self.options.declare
-        declare("n_comp", 1, types=int, desc="Number of principal components")
+        declare(
+            "n_comp",
+            1,
+            types=(list, tuple, np.ndarray, int),
+            desc="Number of principal components",
+        )
         # KPLS used only with "abs_exp", "squar_exp" and "pow_exp" correlations
         declare(
             "corr",
@@ -96,7 +101,7 @@ class KPLS(KrgBased):
         )
         return d
 
-    def _estimate_number_of_components(self):
+    def _estimate_number_of_components_opt(self):
         """
         self.options[n_comp] value from user is ignored and replaced by an estimated one wrt Wold's R criterion.
         """
@@ -104,6 +109,8 @@ class KPLS(KrgBased):
         X = self.training_points[None][0][0]
         y = self.training_points[None][0][1]
         k_fold = 4
+        if self.nt < k_fold:
+            k_fold = self.nt
         nbk = int(self.nt / k_fold)
         press_m = 0.0
         press_m1 = 0.0
@@ -117,9 +124,7 @@ class KPLS(KrgBased):
             for fold in range(k_fold):
                 self.nt = len(X) - nbk
                 todel = np.arange(fold * nbk, (fold + 1) * nbk)
-                Xfold = np.copy(X)
                 Xfold = np.delete(X, todel, axis=0)
-                yfold = np.copy(y)
                 yfold = np.delete(y, todel, axis=0)
                 Xtest = np.copy(X)[fold * nbk : (fold + 1) * nbk, :]
                 ytest = np.copy(y)[fold * nbk : (fold + 1) * nbk, :]
@@ -142,6 +147,50 @@ class KPLS(KrgBased):
         self.nt = len(X)
         self._theta0 = [0.1]
 
+    def _estimate_number_of_components_from_range(self):
+        """
+        If self.options[n_comp] is an array-like with two values n_comp_min, n_comp_max we test the
+        range between the two values and we select the best n_dim based on the Wold's R criterion.
+        """
+        X = self.training_points[None][0][0]
+        y = self.training_points[None][0][1]
+        k_fold = 4
+        if self.nt < k_fold:
+            k_fold = self.nt
+        nbk = int(self.nt / k_fold)
+        press_m = []
+        n_comp_min, n_comp_max = map(int, self.options["n_comp"])  # We want int only
+        n_comp_values = list(range(n_comp_min, n_comp_max + 1))
+        for n_comp in n_comp_values:
+            self.options["n_comp"] = n_comp
+            self._theta0 = [0.1]
+            press_m.append(0.0)
+            for fold in range(k_fold):
+                self.nt = len(X) - nbk
+                todel = np.arange(fold * nbk, (fold + 1) * nbk)
+                Xfold = np.delete(X, todel, axis=0)
+                yfold = np.delete(y, todel, axis=0)
+                Xtest = np.copy(X)[fold * nbk : (fold + 1) * nbk, :]
+                ytest = np.copy(y)[fold * nbk : (fold + 1) * nbk, :]
+
+                self.training_points[None][0][0] = Xfold
+                self.training_points[None][0][1] = yfold
+                try:
+                    self._new_train()
+                except ValueError:
+                    press_m[-1] = np.inf
+                    break
+                ye = self._predict_values(Xtest)
+                press_m[-1] = press_m[-1] + np.sum(
+                    np.power((1 / len(X)) * (ye - ytest), 2)
+                )
+
+        self.options["n_comp"] = n_comp_values[np.argmin(press_m)]
+        self.training_points[None][0][0] = X
+        self.training_points[None][0][1] = y
+        self.nt = len(X)
+        self._theta0 = [0.1]
+
     def _train(self):
         """
         Train the model
@@ -149,5 +198,15 @@ class KPLS(KrgBased):
         # outputs['sol'] = self.sol
 
         if self.options["eval_n_comp"]:
-            self._estimate_number_of_components()
+            self._estimate_number_of_components_opt()
+        n_comp = np.asarray(self.options["n_comp"])
+        if n_comp.ndim == 1 and n_comp.size == 2:
+            self._estimate_number_of_components_from_range()
+        elif n_comp.ndim == 0:
+            pass  # single value, continue training
+        else:
+            raise ValueError(
+                "n_comp must be an integer or an array-like of length 2 "
+                "[min_n_comp, max_n_comp], with min_n_comp < max_n_comp"
+            )
         self._new_train()

--- a/smt/surrogate_models/kpls.py
+++ b/smt/surrogate_models/kpls.py
@@ -21,11 +21,15 @@ class KPLS(KrgBased):
     def _initialize(self):
         super(KPLS, self)._initialize()
         declare = self.options.declare
+
         declare(
             "n_comp",
             1,
-            types=(list, tuple, np.ndarray, int),
-            desc="Number of principal components",
+            types=int,
+            desc=(
+                "Number of principal components. Only used when eval_n_comp=False. "
+                "Ignored when eval_n_comp=True (the optimal value is estimated instead)."
+            ),
         )
         # KPLS used only with "abs_exp", "squar_exp" and "pow_exp" correlations
         declare(
@@ -33,20 +37,48 @@ class KPLS(KrgBased):
             "squar_exp",
             values=("abs_exp", "squar_exp", "pow_exp"),
             desc="Correlation function type",
-            types=(str),
+            types=str,
         )
         declare(
             "eval_n_comp",
             False,
-            types=(bool),
+            types=bool,
             values=(True, False),
-            desc="n_comp evaluation flag",
+            desc=(
+                "If True, the optimal number of components is estimated automatically "
+                "using the strategy defined by eval_n_comp_strategy. "
+                "If False, the value of n_comp is used directly."
+            ),
         )
         declare(
             "eval_comp_treshold",
             1.0,
-            types=(float),
-            desc="n_comp evaluation treshold for Wold's R criterion",
+            types=float,
+            desc="Threshold for Wold's R criterion (used when eval_n_comp_strategy='wold').",
+        )
+        declare(
+            "eval_n_comp_strategy",
+            "wold",
+            values=("wold", "exhaustive"),
+            types=str,
+            desc=(
+                "Strategy used to estimate the optimal number of components when "
+                "eval_n_comp=True. "
+                "'wold': increments n_comp until the cross-validation error stops "
+                "decreasing (early stopping via Wold's R criterion). "
+                "'exhaustive': evaluates all values in range_n_comp_exhaustive and "
+                "picks the global minimum."
+            ),
+        )
+        declare(
+            "range_n_comp_exhaustive",
+            None,
+            types=(list, tuple, np.ndarray, type(None)),
+            desc=(
+                "Search range [n_min, n_max] (inclusive) for the exhaustive strategy. "
+                "Only used when eval_n_comp=True and eval_n_comp_strategy='exhaustive'. "
+                "If None, defaults to [1, max(1, n_features // 10)]."
+            ),
         )
         declare(
             "cat_kernel_comps",
@@ -87,7 +119,151 @@ class KPLS(KrgBased):
         ):
             if self.options["cat_kernel_comps"] is not None:
                 raise ValueError("cat_kernel_comps option is for homoscedastic kernel.")
+
+        if not self.options["eval_n_comp"]:
+            if (
+                not isinstance(self.options["n_comp"], int)
+                or self.options["n_comp"] < 1
+            ):
+                raise ValueError(
+                    "n_comp must be a positive integer when eval_n_comp=False."
+                )
+
+        if (
+            self.options["eval_n_comp"]
+            and self.options["eval_n_comp_strategy"] == "exhaustive"
+            and self.options["range_n_comp_exhaustive"] is not None
+        ):
+            r = self.options["range_n_comp_exhaustive"]
+            if len(r) != 2 or int(r[0]) >= int(r[1]):
+                raise ValueError(
+                    "range_n_comp_exhaustive must be a two-element array-like "
+                    "[n_min, n_max] with n_min < n_max."
+                )
+
         super()._check_param()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _get_exhaustive_range(self):
+        """
+        Returns (n_min, n_max) for the exhaustive search.
+        Falls back to [1, max(1, n_features // 10)] when the option is None.
+        """
+        r = self.options["range_n_comp_exhaustive"]
+        if r is None:
+            n_features = self.training_points[None][0][0].shape[1]
+            n_max = max(1, n_features // 10)
+            return 1, n_max
+        return int(r[0]), int(r[1])
+
+    def _calculate_press_error(self, X, y, n_comp, k_fold, original_nt):
+        """
+        Computes the k-fold cross-validation PRESS error for a given n_comp.
+
+        Parameters
+        ----------
+        X : ndarray, shape (original_nt, n_features) — full training inputs, never mutated
+        y : ndarray, shape (original_nt, n_outputs)  — full training outputs, never mutated
+        n_comp : int — number of PLS components to use
+        k_fold : int — number of folds
+        original_nt : int — size of the full dataset; used to compute fold width
+                      and the PRESS normalisation factor. Passed explicitly so
+                      this method does not depend on self.nt, which may have
+                      been overwritten by a previous fold.
+
+        Returns np.inf if training fails for any fold.
+        """
+        nbk = int(original_nt / k_fold)
+        press = 0.0
+        for fold in range(k_fold):
+            todel = np.arange(fold * nbk, (fold + 1) * nbk)
+            Xfold = np.delete(X, todel, axis=0)
+            yfold = np.delete(y, todel, axis=0)
+            Xtest = X[fold * nbk : (fold + 1) * nbk, :]
+            ytest = y[fold * nbk : (fold + 1) * nbk, :]
+
+            # Reset theta0 before each fold so optimisation starts from the
+            # same point regardless of what _new_train set in the previous fold
+            self._theta0 = [0.1]
+            self.nt = len(Xfold)
+            self.training_points[None][0][0] = Xfold
+            self.training_points[None][0][1] = yfold
+            try:
+                self._new_train()
+            except ValueError:
+                return np.inf
+            ye = self._predict_values(Xtest)
+            press += np.sum(np.power((1 / original_nt) * (ye - ytest), 2))
+        return press
+
+    def _estimate_number_of_components(self):
+        """
+        Unified component-count estimator.
+
+        - strategy='wold'      : increments n_comp one at a time and stops as
+                                 soon as the PRESS error increases relative to
+                                 the previous step (Wold's R criterion).
+        - strategy='exhaustive': evaluates every integer in
+                                 range_n_comp_exhaustive (or the auto-derived
+                                 range) and returns the global minimum.
+        """
+        strategy = self.options["eval_n_comp_strategy"]
+        eval_comp_treshold = self.options["eval_comp_treshold"]
+
+        X = self.training_points[None][0][0].copy()
+        y = self.training_points[None][0][1].copy()
+        original_nt = len(X)
+
+        k_fold = min(4, original_nt)
+        best_comp = 1
+        best_error = np.inf
+
+        # Need at least 2 folds to have both a train and a validation split
+        if k_fold < 2:
+            self.options["n_comp"] = best_comp
+            return
+
+        if strategy == "wold":
+            n_comp = 0
+            prev_error = np.inf
+            while True:
+                n_comp += 1
+                self.options["n_comp"] = n_comp
+                error = self._calculate_press_error(X, y, n_comp, k_fold, original_nt)
+
+                if error == np.inf:
+                    # Training failed: revert to last good value
+                    n_comp -= 1
+                    break
+
+                if n_comp > 1 and error / prev_error > eval_comp_treshold:
+                    # Error increased beyond threshold: keep previous n_comp
+                    n_comp -= 1
+                    break
+
+                best_comp = n_comp
+                prev_error = error
+
+        elif strategy == "exhaustive":
+            n_min, n_max = self._get_exhaustive_range()
+            for n_comp in range(n_min, n_max + 1):
+                self.options["n_comp"] = n_comp
+                error = self._calculate_press_error(X, y, n_comp, k_fold, original_nt)
+                if error < best_error:
+                    best_error = error
+                    best_comp = n_comp
+
+        # Restore training data and state
+        self.training_points[None][0][0] = X
+        self.training_points[None][0][1] = y
+        self.nt = original_nt
+        self._theta0 = [0.1]
+        self.options["n_comp"] = best_comp
+
+    # ------------------------------------------------------------------
 
     def _componentwise_distance(self, dx, theta=None, return_derivative=False):
         d = componentwise_distance_PLS(
@@ -101,117 +277,15 @@ class KPLS(KrgBased):
         )
         return d
 
-    def _estimate_number_of_components_opt(self):
-        """
-        self.options[n_comp] value from user is ignored and replaced by an estimated one wrt Wold's R criterion.
-        """
-        eval_comp_treshold = self.options["eval_comp_treshold"]
-        X = self.training_points[None][0][0]
-        y = self.training_points[None][0][1]
-        k_fold = 4
-        if self.nt < k_fold:
-            k_fold = self.nt
-        nbk = int(self.nt / k_fold)
-        press_m = 0.0
-        press_m1 = 0.0
-        self.options["n_comp"] = 0
-        nextcomp = True
-        while nextcomp:
-            self.options["n_comp"] += 1
-            press_m = press_m1
-            press_m1 = 0
-            self._theta0 = [0.1]
-            for fold in range(k_fold):
-                self.nt = len(X) - nbk
-                todel = np.arange(fold * nbk, (fold + 1) * nbk)
-                Xfold = np.delete(X, todel, axis=0)
-                yfold = np.delete(y, todel, axis=0)
-                Xtest = np.copy(X)[fold * nbk : (fold + 1) * nbk, :]
-                ytest = np.copy(y)[fold * nbk : (fold + 1) * nbk, :]
-
-                self.training_points[None][0][0] = Xfold
-                self.training_points[None][0][1] = yfold
-                try:
-                    self._new_train()
-                except ValueError:
-                    self.options["n_comp"] -= 1
-                    nextcomp = False
-                    break
-                ye = self._predict_values(Xtest)
-                press_m1 = press_m1 + np.sum(np.power((1 / len(X)) * (ye - ytest), 2))
-            if self.options["n_comp"] > 1 and press_m1 / press_m > eval_comp_treshold:
-                self.options["n_comp"] -= 1
-                nextcomp = False
-        self.training_points[None][0][0] = X
-        self.training_points[None][0][1] = y
-        self.nt = len(X)
-        self._theta0 = [0.1]
-
-    def _estimate_number_of_components_from_range(self):
-        """
-        If self.options[n_comp] is an array-like with two values n_comp_min, n_comp_max we test the
-        range between the two values and we select the best n_dim based on the Wold's R criterion.
-        """
-        X = self.training_points[None][0][0]
-        y = self.training_points[None][0][1]
-        k_fold = 4
-        if self.nt < k_fold:
-            k_fold = self.nt
-        nbk = int(self.nt / k_fold)
-        press_m = []
-        n_comp_min, n_comp_max = map(int, self.options["n_comp"])  # We want int only
-        if n_comp_min >= n_comp_max:
-            raise ValueError(
-                "n_comp must be an integer or an array-like of length 2 "
-                "[min_n_comp, max_n_comp], with min_n_comp < max_n_comp"
-            )
-        n_comp_values = list(range(n_comp_min, n_comp_max + 1))
-        for n_comp in n_comp_values:
-            self.options["n_comp"] = n_comp
-            self._theta0 = [0.1]
-            press_m.append(0.0)
-            for fold in range(k_fold):
-                self.nt = len(X) - nbk
-                todel = np.arange(fold * nbk, (fold + 1) * nbk)
-                Xfold = np.delete(X, todel, axis=0)
-                yfold = np.delete(y, todel, axis=0)
-                Xtest = np.copy(X)[fold * nbk : (fold + 1) * nbk, :]
-                ytest = np.copy(y)[fold * nbk : (fold + 1) * nbk, :]
-
-                self.training_points[None][0][0] = Xfold
-                self.training_points[None][0][1] = yfold
-                try:
-                    self._new_train()
-                except ValueError:
-                    press_m[-1] = np.inf
-                    break
-                ye = self._predict_values(Xtest)
-                press_m[-1] = press_m[-1] + np.sum(
-                    np.power((1 / len(X)) * (ye - ytest), 2)
-                )
-
-        self.options["n_comp"] = n_comp_values[np.argmin(press_m)]
-        self.training_points[None][0][0] = X
-        self.training_points[None][0][1] = y
-        self.nt = len(X)
-        self._theta0 = [0.1]
-
     def _train(self):
         """
-        Train the model
-        """
-        # outputs['sol'] = self.sol
+        Train the model.
 
+        If eval_n_comp=True the optimal number of components is estimated first
+        using the configured strategy, then the model is trained with that value.
+        If eval_n_comp=False the user-supplied n_comp is used directly.
+        """
         if self.options["eval_n_comp"]:
-            self._estimate_number_of_components_opt()
-        n_comp = np.asarray(self.options["n_comp"])
-        if n_comp.ndim == 1 and n_comp.size == 2:
-            self._estimate_number_of_components_from_range()
-        elif n_comp.ndim == 0:
-            pass  # single value, continue training
-        else:
-            raise ValueError(
-                "n_comp must be an integer or an array-like of length 2 "
-                "[min_n_comp, max_n_comp], with min_n_comp < max_n_comp"
-            )
+            self._estimate_number_of_components()
+
         self._new_train()

--- a/smt/surrogate_models/tests/test_kpls_auto.py
+++ b/smt/surrogate_models/tests/test_kpls_auto.py
@@ -1,6 +1,5 @@
 """
 Author: Paul Saves
-
 This package is distributed under New BSD license.
 """
 
@@ -67,10 +66,11 @@ class Test(SMTestCase):
         xe = sampling(self.ne)
         ye = prob(xe)
 
-        sm0 = KPLS(eval_n_comp=True)
-
-        sm = sm0.__class__()
-        sm.options = sm0.options.clone()
+        sm = KPLS(
+            eval_n_comp=True,
+            eval_n_comp_strategy="wold",
+            print_global=False,
+        )
         if sm.options.is_declared("xlimits"):
             sm.options["xlimits"] = prob.xlimits
         sm.options["print_global"] = False
@@ -86,14 +86,18 @@ class Test(SMTestCase):
         e_error = compute_relative_error(sm, xe, ye)
 
         if print_output:
-            print("%8s %6s %18.9e %18.9e" % (pname[:6], sname, t_error, e_error))
+            print(
+                "%8s %6s  n_comp=%d  %18.9e %18.9e"
+                % (pname[:6], sname, ncomp, t_error, e_error)
+            )
 
         self.assert_error(t_error, 0.0, self.t_errors[sname], 1e-5)
         self.assert_error(e_error, 0.0, self.e_errors[sname], 1e-5)
         self.assertEqual(ncomp, self.n_comp_opt[pname])
 
-    # --------------------------------------------------------------------
-    # Function: sphere
+    # ------------------------------------------------------------------
+    # Test cases
+    # ------------------------------------------------------------------
 
     def test_Branin_KPLS(self):
         self.run_test()

--- a/smt/surrogate_models/tests/test_kpls_range.py
+++ b/smt/surrogate_models/tests/test_kpls_range.py
@@ -1,0 +1,111 @@
+"""
+Author: Enrico Stragiotti
+
+This package is distributed under New BSD license.
+"""
+
+import unittest
+from collections import OrderedDict
+
+from smt.problems import Branin, Rosenbrock, Sphere, TensorProduct
+from smt.sampling_methods import LHS
+from smt.surrogate_models import KPLS
+from smt.utils.misc import compute_relative_error
+from smt.utils.silence import Silence
+from smt.utils.sm_test_case import SMTestCase
+
+print_output = False
+
+
+class Test(SMTestCase):
+    def setUp(self):
+        ndim = 10
+        nt = 50
+        ne = 100
+
+        problems = OrderedDict()
+        problems["Branin"] = Branin(ndim=2)
+        problems["Rosenbrock"] = Rosenbrock(ndim=3)
+        problems["sphere"] = Sphere(ndim=ndim)
+        problems["exp"] = TensorProduct(ndim=ndim, func="exp")
+        problems["tanh"] = TensorProduct(ndim=ndim, func="tanh")
+        problems["cos"] = TensorProduct(ndim=ndim, func="cos")
+
+        t_errors = {}
+        e_errors = {}
+        t_errors["KPLS"] = 1e-3
+        e_errors["KPLS"] = 2.5
+
+        n_comp_opt = {}
+        n_comp_opt["Branin"] = 1
+        n_comp_opt["Rosenbrock"] = 1
+        n_comp_opt["sphere"] = 2
+        n_comp_opt["exp"] = 5
+        n_comp_opt["tanh"] = 1
+        n_comp_opt["cos"] = 1
+
+        self.nt = nt
+        self.ne = ne
+        self.problems = problems
+        self.t_errors = t_errors
+        self.e_errors = e_errors
+        self.n_comp_opt = n_comp_opt
+
+    def run_range_test(self, pname, sname, n_comp_range):
+        prob = self.problems[pname]
+
+        sampling = LHS(xlimits=prob.xlimits, seed=42)
+
+        xt = sampling(self.nt)
+        yt = prob(xt)
+
+        xe = sampling(self.ne)
+        ye = prob(xe)
+
+        sm0 = KPLS(eval_n_comp=False)
+
+        sm = sm0.__class__()
+        sm.options = sm0.options.clone()
+
+        if sm.options.is_declared("xlimits"):
+            sm.options["xlimits"] = prob.xlimits
+
+        sm.options["print_global"] = False
+
+        sm.options["n_comp"] = n_comp_range
+
+        sm.set_training_values(xt, yt)
+
+        with Silence():
+            sm.train()
+
+        ncomp = sm.options["n_comp"]
+
+        t_error = compute_relative_error(sm)
+        e_error = compute_relative_error(sm, xe, ye)
+
+        if print_output:
+            print("%8s %6s %18.9e %18.9e" % (pname[:6], sname, t_error, e_error))
+
+        self.assert_error(t_error, 0.0, self.t_errors[sname], 1e-5)
+        self.assert_error(e_error, 0.0, self.e_errors[sname], 1e-5)
+        self.assertIsInstance(ncomp, int)
+        self.assertGreaterEqual(ncomp, n_comp_range[0])
+        self.assertLessEqual(ncomp, n_comp_range[1])
+
+    # --------------------------------------------------------------------
+
+    def test_Branin_KPLS_range(self):
+        self.run_range_test("Branin", "KPLS", [1, 3])
+
+    def test_sphere_KPLS_range(self):
+        self.run_range_test("sphere", "KPLS", [1, 5])
+
+    def test_exp_KPLS_range(self):
+        self.run_range_test("exp", "KPLS", [3, 6])
+
+
+if __name__ == "__main__":
+    print_output = True
+    print("%6s %8s %18s %18s" % ("SM", "Problem", "Train. pt. error", "Test pt. error"))
+    unittest.main()

--- a/smt/surrogate_models/tests/test_kpls_range.py
+++ b/smt/surrogate_models/tests/test_kpls_range.py
@@ -4,6 +4,8 @@ Author: Enrico Stragiotti
 This package is distributed under New BSD license.
 """
 
+import inspect
+import os
 import unittest
 from collections import OrderedDict
 
@@ -39,7 +41,7 @@ class Test(SMTestCase):
         n_comp_opt = {}
         n_comp_opt["Branin"] = 1
         n_comp_opt["Rosenbrock"] = 1
-        n_comp_opt["sphere"] = 2
+        n_comp_opt["sphere"] = 5
         n_comp_opt["exp"] = 5
         n_comp_opt["tanh"] = 1
         n_comp_opt["cos"] = 1
@@ -51,7 +53,10 @@ class Test(SMTestCase):
         self.e_errors = e_errors
         self.n_comp_opt = n_comp_opt
 
-    def run_range_test(self, pname, sname, n_comp_range):
+    def run_range_test(self, n_comp_range):
+        method_name = inspect.stack()[1][3]
+        pname = method_name.split("_")[1]
+        sname = method_name.split("_")[2]
         prob = self.problems[pname]
 
         sampling = LHS(xlimits=prob.xlimits, seed=42)
@@ -92,17 +97,32 @@ class Test(SMTestCase):
         self.assertIsInstance(ncomp, int)
         self.assertGreaterEqual(ncomp, n_comp_range[0])
         self.assertLessEqual(ncomp, n_comp_range[1])
+        self.assertEqual(ncomp, self.n_comp_opt[pname])
 
     # --------------------------------------------------------------------
 
     def test_Branin_KPLS_range(self):
-        self.run_range_test("Branin", "KPLS", [1, 3])
+        self.run_range_test([1, 3])
 
+    @unittest.skipIf(int(os.getenv("RUN_SLOW_TESTS", 0)) < 1, "too slow")
+    def test_Rosenbrock_KPLS(self):
+        self.run_range_test([1, 3])
+
+    @unittest.skipIf(int(os.getenv("RUN_SLOW_TESTS", 0)) < 1, "too slow")
     def test_sphere_KPLS_range(self):
-        self.run_range_test("sphere", "KPLS", [1, 5])
+        self.run_range_test([2, 6])
 
+    @unittest.skipIf(int(os.getenv("RUN_SLOW_TESTS", 0)) < 1, "too slow")
     def test_exp_KPLS_range(self):
-        self.run_range_test("exp", "KPLS", [3, 6])
+        self.run_range_test([3, 6])
+
+    @unittest.skipIf(int(os.getenv("RUN_SLOW_TESTS", 0)) < 1, "too slow")
+    def test_tanh_KPLS(self):
+        self.run_range_test([1, 3])
+
+    @unittest.skipIf(int(os.getenv("RUN_SLOW_TESTS", 0)) < 1, "too slow")
+    def test_cos_KPLS(self):
+        self.run_range_test([1, 3])
 
 
 if __name__ == "__main__":

--- a/smt/surrogate_models/tests/test_kpls_range.py
+++ b/smt/surrogate_models/tests/test_kpls_range.py
@@ -4,6 +4,7 @@ This package is distributed under New BSD license.
 """
 
 import inspect
+import os
 import unittest
 from collections import OrderedDict
 
@@ -64,15 +65,13 @@ class Test(SMTestCase):
 
         xe = sampling(self.ne)
         ye = prob(xe)
-        sm0 = KPLS(
+
+        sm = KPLS(
             eval_n_comp=True,
             eval_n_comp_strategy="exhaustive",
             range_n_comp_exhaustive=n_comp_range,
             print_global=False,
         )
-
-        sm = sm0.__class__()
-        sm.options = sm0.options.clone()
 
         if sm.options.is_declared("xlimits"):
             sm.options["xlimits"] = prob.xlimits
@@ -108,23 +107,23 @@ class Test(SMTestCase):
     def test_Branin_KPLS_range(self):
         self.run_range_test([1, 3])
 
-    # @unittest.skipIf(int(os.getenv("RUN_SLOW_TESTS", 0)) < 1, "too slow")
+    @unittest.skipIf(int(os.getenv("RUN_SLOW_TESTS", 0)) < 1, "too slow")
     def test_Rosenbrock_KPLS(self):
         self.run_range_test([1, 3])
 
-    # @unittest.skipIf(int(os.getenv("RUN_SLOW_TESTS", 0)) < 1, "too slow")
+    @unittest.skipIf(int(os.getenv("RUN_SLOW_TESTS", 0)) < 1, "too slow")
     def test_sphere_KPLS_range(self):
         self.run_range_test([2, 6])
 
-    # @unittest.skipIf(int(os.getenv("RUN_SLOW_TESTS", 0)) < 1, "too slow")
+    @unittest.skipIf(int(os.getenv("RUN_SLOW_TESTS", 0)) < 1, "too slow")
     def test_exp_KPLS_range(self):
         self.run_range_test([3, 6])
 
-    # @unittest.skipIf(int(os.getenv("RUN_SLOW_TESTS", 0)) < 1, "too slow")
+    @unittest.skipIf(int(os.getenv("RUN_SLOW_TESTS", 0)) < 1, "too slow")
     def test_tanh_KPLS(self):
         self.run_range_test([1, 3])
 
-    # @unittest.skipIf(int(os.getenv("RUN_SLOW_TESTS", 0)) < 1, "too slow")
+    @unittest.skipIf(int(os.getenv("RUN_SLOW_TESTS", 0)) < 1, "too slow")
     def test_cos_KPLS(self):
         self.run_range_test([1, 3])
 

--- a/smt/surrogate_models/tests/test_kpls_range.py
+++ b/smt/surrogate_models/tests/test_kpls_range.py
@@ -1,11 +1,9 @@
 """
 Author: Enrico Stragiotti
-
 This package is distributed under New BSD license.
 """
 
 import inspect
-import os
 import unittest
 from collections import OrderedDict
 
@@ -66,8 +64,12 @@ class Test(SMTestCase):
 
         xe = sampling(self.ne)
         ye = prob(xe)
-
-        sm0 = KPLS(eval_n_comp=False)
+        sm0 = KPLS(
+            eval_n_comp=True,
+            eval_n_comp_strategy="exhaustive",
+            range_n_comp_exhaustive=n_comp_range,
+            print_global=False,
+        )
 
         sm = sm0.__class__()
         sm.options = sm0.options.clone()
@@ -76,8 +78,6 @@ class Test(SMTestCase):
             sm.options["xlimits"] = prob.xlimits
 
         sm.options["print_global"] = False
-
-        sm.options["n_comp"] = n_comp_range
 
         sm.set_training_values(xt, yt)
 
@@ -90,8 +90,10 @@ class Test(SMTestCase):
         e_error = compute_relative_error(sm, xe, ye)
 
         if print_output:
-            print("%8s %6s %18.9e %18.9e" % (pname[:6], sname, t_error, e_error))
-
+            print(
+                "%8s %6s  n_comp=%d  %18.9e %18.9e"
+                % (pname[:6], sname, ncomp, t_error, e_error)
+            )
         self.assert_error(t_error, 0.0, self.t_errors[sname], 1e-5)
         self.assert_error(e_error, 0.0, self.e_errors[sname], 1e-5)
         self.assertIsInstance(ncomp, int)
@@ -99,28 +101,30 @@ class Test(SMTestCase):
         self.assertLessEqual(ncomp, n_comp_range[1])
         self.assertEqual(ncomp, self.n_comp_opt[pname])
 
-    # --------------------------------------------------------------------
+    # ------------------------------------------------------------------
+    # Test cases
+    # ------------------------------------------------------------------
 
     def test_Branin_KPLS_range(self):
         self.run_range_test([1, 3])
 
-    @unittest.skipIf(int(os.getenv("RUN_SLOW_TESTS", 0)) < 1, "too slow")
+    # @unittest.skipIf(int(os.getenv("RUN_SLOW_TESTS", 0)) < 1, "too slow")
     def test_Rosenbrock_KPLS(self):
         self.run_range_test([1, 3])
 
-    @unittest.skipIf(int(os.getenv("RUN_SLOW_TESTS", 0)) < 1, "too slow")
+    # @unittest.skipIf(int(os.getenv("RUN_SLOW_TESTS", 0)) < 1, "too slow")
     def test_sphere_KPLS_range(self):
         self.run_range_test([2, 6])
 
-    @unittest.skipIf(int(os.getenv("RUN_SLOW_TESTS", 0)) < 1, "too slow")
+    # @unittest.skipIf(int(os.getenv("RUN_SLOW_TESTS", 0)) < 1, "too slow")
     def test_exp_KPLS_range(self):
         self.run_range_test([3, 6])
 
-    @unittest.skipIf(int(os.getenv("RUN_SLOW_TESTS", 0)) < 1, "too slow")
+    # @unittest.skipIf(int(os.getenv("RUN_SLOW_TESTS", 0)) < 1, "too slow")
     def test_tanh_KPLS(self):
         self.run_range_test([1, 3])
 
-    @unittest.skipIf(int(os.getenv("RUN_SLOW_TESTS", 0)) < 1, "too slow")
+    # @unittest.skipIf(int(os.getenv("RUN_SLOW_TESTS", 0)) < 1, "too slow")
     def test_cos_KPLS(self):
         self.run_range_test([1, 3])
 

--- a/smt/surrogate_models/tests/test_surrogate_model_examples.py
+++ b/smt/surrogate_models/tests/test_surrogate_model_examples.py
@@ -395,14 +395,57 @@ class Test(unittest.TestCase):
         ndim = 10
         prob = TensorProduct(ndim=ndim, func="exp")
 
-        sm = KPLS(eval_n_comp=True)
+        sm = KPLS(
+            eval_n_comp=True,
+            eval_n_comp_strategy="wold",
+        )
         samp = LHS(xlimits=prob.xlimits, seed=42)
         xt = samp(50)
         yt = prob(xt)
         sm.set_training_values(xt, yt)
         sm.train()
 
-        ## The model automatically choose a dimension of 3
+        ## The model automatically choose a dimension of 5
+        ncomp = sm.options["n_comp"]
+        print("\n The model automatically choose " + str(ncomp) + " components.")
+
+        ## You can predict a 10-dimension point from the 3-dimensional model
+        print(
+            sm.predict_values(
+                np.array([[-0.9, -0.7, -0.5, -0.3, -0.1, 0.1, 0.3, 0.5, 0.7, 0.9]])
+            )
+        )
+        print(
+            sm.predict_variances(
+                np.array([[-0.9, -0.7, -0.5, -0.3, -0.1, 0.1, 0.3, 0.5, 0.7, 0.9]])
+            )
+        )
+
+    def test_kpls_range(self):
+        import numpy as np
+
+        from smt.problems import TensorProduct
+        from smt.sampling_methods import LHS
+        from smt.surrogate_models import KPLS
+
+        # The problem is the exponential problem with dimension 10
+        ndim = 10
+        prob = TensorProduct(ndim=ndim, func="exp")
+
+        n_comp_range = [2, 6]  # We explore the range [1, 5] n_dim and we chose the best
+
+        sm = KPLS(
+            eval_n_comp=True,
+            eval_n_comp_strategy="exhaustive",
+            range_n_comp_exhaustive=n_comp_range,
+        )
+        samp = LHS(xlimits=prob.xlimits, seed=42)
+        xt = samp(50)
+        yt = prob(xt)
+        sm.set_training_values(xt, yt)
+        sm.train()
+
+        ## The model automatically choose a dimension of 5
         ncomp = sm.options["n_comp"]
         print("\n The model automatically choose " + str(ncomp) + " components.")
 


### PR DESCRIPTION
… and test the range of n_dim and choose the best one. It has been refactored to take into account the advice given by @Paul-Saves.

I added unit tests (some of them are quite long due to the exhaustive search, so I marked them as `@unittest.skipIf(int(os.getenv("RUN_SLOW_TESTS", 0)) < 1, "too slow")`).

I updated the docs with a new example and added some description to the parameters.

I also added a little safeguard on the number of k_fold min based on the number of training points:
```python
k_fold = min(4, original_nt)
```